### PR TITLE
Cap square/connect version to resolve deprecation exceptions

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
         "illuminate/contracts": "~5.5|~5.6|~5.7",
         "illuminate/container": "~5.5|~5.6|~5.7",
         "illuminate/database": "~5.5|~5.6|~5.7",
-        "square/connect": "^2.5",
+        "square/connect": "<2.20190814",
         "nikolag/core": "2.x-dev"
     },
     "require-dev": {


### PR DESCRIPTION
Deprecation annotations were added in the 2019-08-14 version of the Square Connect SDK. By using a prior version of the SDK these exceptions will no longer be issued.