### PR TITLE
UpdateCustomerRequest use to fix Square TypeError

### DIFF
--- a/src/SquareService.php
+++ b/src/SquareService.php
@@ -385,10 +385,10 @@ class SquareService extends CorePaymentService implements SquareServiceContract
     }
 
     /**
-     * @param  CreateCustomerRequest  $createCustomerRequest
+     * @param  CreateCustomerRequest|UpdateCustomerRequest  $createCustomerRequest
      * @return self
      */
-    public function setCreateCustomerRequest(CreateCustomerRequest $createCustomerRequest)
+    public function setCreateCustomerRequest($createCustomerRequest)
     {
         $this->createCustomerRequest = $createCustomerRequest;
 

--- a/src/builders/SquareRequestBuilder.php
+++ b/src/builders/SquareRequestBuilder.php
@@ -18,6 +18,7 @@ use Square\Models\OrderLineItemAppliedDiscount;
 use Square\Models\OrderLineItemAppliedTax;
 use Square\Models\OrderLineItemDiscount;
 use Square\Models\OrderLineItemTax;
+use Square\Models\UpdateCustomerRequest;
 
 class SquareRequestBuilder
 {
@@ -67,11 +68,15 @@ class SquareRequestBuilder
      * Create and return customer request.
      *
      * @param  Model  $customer
-     * @return CreateCustomerRequest
+     * @return CreateCustomerRequest|UpdateCustomerRequest
      */
     public function buildCustomerRequest(Model $customer)
     {
-        $request = new CreateCustomerRequest();
+        if ($customer->payment_service_id) {
+            $request = new UpdateCustomerRequest();
+        } else {
+            $request = new CreateCustomerRequest();
+        }
         $request->setGivenName($customer->first_name);
         $request->setFamilyName($customer->last_name);
         $request->setCompanyName($customer->company_name);


### PR DESCRIPTION
Every time setCustomer with old $customer was called, this error occured:

> TypeError: Argument 2 passed to Square\Apis\CustomersApi::updateCustomer() must be an instance of Square\Models\UpdateCustomerRequest, instance of Square\Models\CreateCustomerRequest given.


fixes NikolaGavric94/laravel-square#70
