### PR TITLE
Add verification token to payment request for 3DS/SCA

### DIFF
--- a/src/SquareService.php
+++ b/src/SquareService.php
@@ -236,6 +236,7 @@ class SquareService extends CorePaymentService implements SquareServiceContract
                 'amount'   => $data['amount'],
                 'currency' => $currency,
             ],
+            'verification_token' => array_key_exists('verification_token', $data) ? $data['verification_token'] : null,
             'autocomplete' => true,
             'source_id' => $data['source_id'],
             'location_id' => $location_id,

--- a/src/SquareService.php
+++ b/src/SquareService.php
@@ -236,13 +236,16 @@ class SquareService extends CorePaymentService implements SquareServiceContract
                 'amount'   => $data['amount'],
                 'currency' => $currency,
             ],
-            'verification_token' => array_key_exists('verification_token', $data) ? $data['verification_token'] : null,
             'autocomplete' => true,
             'source_id' => $data['source_id'],
             'location_id' => $location_id,
             'note' => array_key_exists('note', $data) ? $data['note'] : null,
             'reference_id' => array_key_exists('reference_id', $data) ? (string) $data['reference_id'] : null,
         ];
+        
+        if (array_key_exists('verification_token', $data) && is_string($data['verification_token'])) {
+            $prepData['verification_token'] = $data['verification_token'];
+        }
 
         // Location id is now mandatory to know under which Location we are doing a charge on
         if (! $prepData['location_id']) {

--- a/src/builders/SquareRequestBuilder.php
+++ b/src/builders/SquareRequestBuilder.php
@@ -59,6 +59,7 @@ class SquareRequestBuilder
         $request->setAutocomplete($prepData['autocomplete']);
         $request->setLocationId($prepData['location_id']);
         $request->setNote($prepData['note']);
+        $request->setVerificationToken($prepData['verification_token']);
         $request->setReferenceId($prepData['reference_id']);
 
         return $request;

--- a/src/builders/SquareRequestBuilder.php
+++ b/src/builders/SquareRequestBuilder.php
@@ -59,8 +59,11 @@ class SquareRequestBuilder
         $request->setAutocomplete($prepData['autocomplete']);
         $request->setLocationId($prepData['location_id']);
         $request->setNote($prepData['note']);
-        $request->setVerificationToken($prepData['verification_token']);
         $request->setReferenceId($prepData['reference_id']);
+        
+        if (array_key_exists('verification_token', $prepData)) {
+            $request->setVerificationToken($prepData['verification_token']);
+        }
 
         return $request;
     }


### PR DESCRIPTION
3D Secure (Strong Customer Authentication, or SCA, in the EEA) requires a verification token that is generated on the frontend be sent with the charge.

This just adds the `verification_token` to the `$prepData` (null if not present) and then sets it in the `CreatePaymentRequest`.


In addition the [Simple Example](https://github.com/NikolaGavric94/laravel-square/wiki/Simple%20Examples) could be updated to
```
$amount = 5000; //Is in USD currency and is in smallest denomination (cents). ($amount = 5000 == 50 Dollars)

// nonce reference => https://developer.squareup.com/docs/payment-form/payment-form-walkthrough
// single-use token (nonce) generated by the client-side javascript library
$formNonce = 'some nonce';

$location_id = 'some location id'; //$location_id is id of a location from Square

// optional, default=USD
$currency = 'USD'; //available currencies => https://developer.squareup.com/reference/square/objects/Currency

// optional
$note = 'This is my first payment to Square with this library'; //note about this charge

// optional
$reference_id = '25'; //some kind of reference id to an object or resource

// optional
$verification_token = 'xxxxxx'; // The 3DS token provided by verifiyBuyer request => https://developer.squareup.com/docs/web-payments/sca

$options = [
  'amount' => $amount,
  'source_id' => $formNonce,
  'location_id' => $location_id,
  'currency' => $currency,
  'note' => $note,
  'reference_id' => $reference_id,
  'verification_token' => $verification_token,
];
```