### PR TITLE
Update Square package to 29.0.0.20230720

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -258,6 +258,10 @@ approach
 ### Added
 - Support for Laravel 10
 
+## [3.2.1] - 2023-08-04
+### Added
+- Updated Square SDK version: [29.0.0.20230720](https://github.com/square/square-php-sdk/tree/29.0.0.20230720)
+
 [Unreleased]: https://github.com/NikolaGavric94/laravel-square/compare/v3.0.1...HEAD
 [1.0.1]: https://github.com/NikolaGavric94/laravel-square/compare/v1.0.0...v1.0.1
 [1.0.2]: https://github.com/NikolaGavric94/laravel-square/compare/v1.0.1...v1.0.2
@@ -282,3 +286,4 @@ approach
 [3.0.2]: https://github.com/NikolaGavric94/laravel-square/compare/v3.0.1...v3.0.2
 [3.1.0]: https://github.com/NikolaGavric94/laravel-square/compare/v3.0.2...v3.1.0
 [3.2.0]: https://github.com/NikolaGavric94/laravel-square/compare/v3.1.0...v3.2.0
+[3.2.1]: https://github.com/NikolaGavric94/laravel-square/compare/v3.2.0...v3.2.1

--- a/README.md
+++ b/README.md
@@ -35,7 +35,8 @@ Square integration with Laravel/Lumen >=5.5 built on [nikolag/core](https://gith
 |:---------------------------------------------------------------------------------:|:-----------------:|:---------------------------------:|
 | [3.0.x](https://github.com/NikolaGavric94/laravel-square/compare/v2.6.0...v3.0.2) |   &nbsp; >= 8.x   | [17.0.0.20211215](https://github.com/square/square-php-sdk/tree/17.0.0.20211215)   |
 | [3.1.x](https://github.com/NikolaGavric94/laravel-square/compare/v3.0.2...v3.1.0) |   &nbsp; >= 9.x   | [25.1.0.20230119](https://github.com/square/square-php-sdk/tree/25.1.0.20230119)   |
-| [3.2.x](https://github.com/NikolaGavric94/laravel-square/compare/v3.2.0...master) |  &nbsp; >= 10.x   | [29.0.0.20230720](https://github.com/square/square-php-sdk/tree/29.0.0.20230720)   |
+| [3.2.0](https://github.com/NikolaGavric94/laravel-square/compare/v3.2.0...3.2.1) |  &nbsp; >= 10.x   | [25.1.0.20230119](https://github.com/square/square-php-sdk/tree/25.1.0.20230119)   |
+| [3.2.x](https://github.com/NikolaGavric94/laravel-square/compare/v3.2.1...master) |  &nbsp; >= 10.x   | [29.0.0.20230720](https://github.com/square/square-php-sdk/tree/29.0.0.20230720)   |
 
 **If you are updating from versions below 3.0 then you need to execute: `php artisan migrate`. This will add some columns required by the library into the tables created by the library, your own tables won't be affected.**
 

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Square integration with Laravel/Lumen >=5.5 built on [nikolag/core](https://gith
 |:---------------------------------------------------------------------------------:|:-----------------:|:---------------------------------:|
 | [3.0.x](https://github.com/NikolaGavric94/laravel-square/compare/v2.6.0...v3.0.2) |   &nbsp; >= 8.x   | [17.0.0.20211215](https://github.com/square/square-php-sdk/tree/17.0.0.20211215)   |
 | [3.1.x](https://github.com/NikolaGavric94/laravel-square/compare/v3.0.2...v3.1.0) |   &nbsp; >= 9.x   | [25.1.0.20230119](https://github.com/square/square-php-sdk/tree/25.1.0.20230119)   |
-| [3.2.x](https://github.com/NikolaGavric94/laravel-square/compare/v3.2.0...master) |  &nbsp; >= 10.x   | [25.1.0.20230119](https://github.com/square/square-php-sdk/tree/25.1.0.20230119)   |
+| [3.2.x](https://github.com/NikolaGavric94/laravel-square/compare/v3.2.0...master) |  &nbsp; >= 10.x   | [29.0.0.20230720](https://github.com/square/square-php-sdk/tree/29.0.0.20230720)   |
 
 **If you are updating from versions below 3.0 then you need to execute: `php artisan migrate`. This will add some columns required by the library into the tables created by the library, your own tables won't be affected.**
 

--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
         "illuminate/filesystem": "10.x",
         "illuminate/support": "10.x",
         "nikolag/core": "2.7.x",
-        "square/square": "25.1.0.20230119"
+        "square/square": "29.0.0.20230720"
     },
     "require-dev": {
         "fakerphp/faker": "^1.13",


### PR DESCRIPTION
Updates the `square/square` package to version `29.0.0.20230720`.

https://github.com/NikolaGavric94/laravel-square/issues/79

- [ ] run tests - did a cursory run and seemed clear.