### PR TITLE
Adds location id to order table

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,6 +7,7 @@ on:
   pull_request:
     branches:
       - 'master'
+      - 'nikolag_master'
       - '3.1.**'
       - '3.2.**'
       - '3.3.**'
@@ -38,8 +39,6 @@ jobs:
     environment: sandbox
     steps:
       - uses: actions/checkout@v3
-        with:
-          ref: '3.3.x'
 
       # Setup php
       - name: Setup PHP with PECL extension

--- a/src/SquareService.php
+++ b/src/SquareService.php
@@ -133,11 +133,15 @@ class SquareService extends CorePaymentService implements SquareServiceContract
      */
     private function _saveOrder(bool $saveToSquare = false): void
     {
-        $this->order = $this->orderBuilder->buildOrderFromOrderCopy($this->getOrder(), $this->orderCopy);
         //If property locationId doesn't exist throw error
         if (! $this->locationId) {
             throw new MissingPropertyException('$locationId property is missing', 500);
         }
+        // Add location id to the order copy
+        $this->orderCopy->location_id = $this->locationId;
+
+        $this->order = $this->orderBuilder->buildOrderFromOrderCopy($this->getOrder(), $this->orderCopy);
+
         //If order doesn't have any products throw error
         if ($this->getOrder()->products()->count() == 0) {
             throw new InvalidSquareOrderException('Object Order must have at least 1 Product', 500);

--- a/src/SquareService.php
+++ b/src/SquareService.php
@@ -199,7 +199,7 @@ class SquareService extends CorePaymentService implements SquareServiceContract
         } catch (MissingPropertyException $e) {
             throw new MissingPropertyException('Required fields are missing', 500, $e);
         } catch (InvalidSquareOrderException $e) {
-            throw new MissingPropertyException('Required column is missing from the table', 500, $e);
+            throw new MissingPropertyException('Invalid order data', 500, $e);
         } catch (Exception|ApiException $e) {
             throw new Exception('There was an error with the api request', 500, $e);
         }
@@ -281,7 +281,7 @@ class SquareService extends CorePaymentService implements SquareServiceContract
             } catch (MissingPropertyException $e) {
                 throw new MissingPropertyException('Required field is missing', 500, $e);
             } catch (InvalidSquareOrderException $e) {
-                throw new MissingPropertyException('Required column is missing from the table', 500, $e);
+                throw new MissingPropertyException('Invalid order data', 500, $e);
             } catch (Exception $e) {
                 throw new Exception('There was an error with the api request', 500, $e);
             }

--- a/src/builders/OrderBuilder.php
+++ b/src/builders/OrderBuilder.php
@@ -48,6 +48,10 @@ class OrderBuilder
         $orderClass = config('nikolag.connections.square.order.namespace');
         // Set payment type to square
         $order->payment_service_type = 'square';
+        // Set location if it's not included in the order
+        if (!$order->location_id) {
+            $order->location_id = $orderCopy->location_id;
+        }
         // Save order first
         $order->save();
 

--- a/src/builders/OrderBuilder.php
+++ b/src/builders/OrderBuilder.php
@@ -49,12 +49,11 @@ class OrderBuilder
         // Set payment type to square
         $order->payment_service_type = 'square';
         // Set location if it's not included in the order
-        if (!$order->location_id) {
+        if (! $order->location_id) {
             $order->location_id = $orderCopy->location_id;
         } elseif ($order->location_id != $orderCopy->location_id) {
             throw new InvalidSquareOrderException(
-                'Location ID conflict.  Order Data: ' . $order->location_id
-                    . '. Order Copy: ' . $orderCopy->location_id,
+                "Location ID conflict. Order Data: {$order->location_id}. Order Copy: {$orderCopy->location_id}",
                 500
             );
         }

--- a/src/builders/OrderBuilder.php
+++ b/src/builders/OrderBuilder.php
@@ -51,7 +51,14 @@ class OrderBuilder
         // Set location if it's not included in the order
         if (!$order->location_id) {
             $order->location_id = $orderCopy->location_id;
+        } elseif ($order->location_id != $orderCopy->location_id) {
+            throw new InvalidSquareOrderException(
+                'Location ID conflict.  Order Data: ' . $order->location_id
+                    . '. Order Copy: ' . $orderCopy->location_id,
+                500
+            );
         }
+
         // Save order first
         $order->save();
 

--- a/src/database/factories/ModelFactory.php
+++ b/src/database/factories/ModelFactory.php
@@ -116,6 +116,7 @@ $factory->state(Constants::TRANSACTION_NAMESPACE, 'FAILED', [
 $factory->define(Order::class, function (Faker\Generator $faker) {
     return [
         'payment_service_type' => 'square',
+        'location_id' => env('SQUARE_LOCATION'),
     ];
 });
 

--- a/src/database/migrations/2024_05_29_145918_add_location_id_to_orders_table.php
+++ b/src/database/migrations/2024_05_29_145918_add_location_id_to_orders_table.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up(): void
+    {
+        Schema::table('nikolag_orders', function (Blueprint $table) {
+            $table->string('location_id', 255);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down(): void
+    {
+        Schema::table('nikolag_orders', function (Blueprint $table) {
+            $table->dropColumn('location_id');
+        });
+    }
+};

--- a/tests/unit/SquareServiceTest.php
+++ b/tests/unit/SquareServiceTest.php
@@ -249,19 +249,19 @@ class SquareServiceTest extends TestCase
                 'note' => 'This note can have maximum of 50 characters.',
                 'price' => 440.99,
                 'quantity' => 2,
-                'reference_id' => '5' //An optional ID to associate the product with an entity ID in your own table
+                'reference_id' => '5', //An optional ID to associate the product with an entity ID in your own table
             ],
             [
                 'name' => 'Shirt',
                 'variation_name' => 'Mid-size yellow',
                 'note' => 'This note can have maximum of 50 characters.',
                 'quantity' => 1,
-                'price' => 118.02
+                'price' => 118.02,
             ],
         ];
 
         $order = [
-            'products' => $products
+            'products' => $products,
         ];
 
         $square = Square::setOrder($order, env('SQUARE_LOCATION'))->save();

--- a/tests/unit/SquareServiceTest.php
+++ b/tests/unit/SquareServiceTest.php
@@ -236,6 +236,42 @@ class SquareServiceTest extends TestCase
     }
 
     /**
+     * Save an order through facade, inputting a simple example (the one currently used in the wiki).
+     *
+     * @return void
+     */
+    public function test_square_order_facade_save_simple_array(): void
+    {
+        $products = [
+            [
+                'name' => 'Shirt',
+                'variation_name' => 'Large white',
+                'note' => 'This note can have maximum of 50 characters.',
+                'price' => 440.99,
+                'quantity' => 2,
+                'reference_id' => '5' //An optional ID to associate the product with an entity ID in your own table
+            ],
+            [
+                'name' => 'Shirt',
+                'variation_name' => 'Mid-size yellow',
+                'note' => 'This note can have maximum of 50 characters.',
+                'quantity' => 1,
+                'price' => 118.02
+            ],
+        ];
+
+        $order = [
+            'products' => $products
+        ];
+
+        $square = Square::setOrder($order, env('SQUARE_LOCATION'))->save();
+
+        $this->assertCount(1, Order::all(), 'There is not enough orders');
+        $this->assertEquals($square->getOrder()->id, Order::find(1)->id, 'Order is not the same as in charge');
+        $this->assertNull($square->getOrder()->payment_service_id, 'Payment service identifier is null');
+    }
+
+    /**
      * Save and charge an order through facade.
      *
      * @return void

--- a/tests/unit/SquareServiceTest.php
+++ b/tests/unit/SquareServiceTest.php
@@ -272,6 +272,27 @@ class SquareServiceTest extends TestCase
     }
 
     /**
+     * Save an order through facade with conflicting location ids.
+     *
+     * @return void
+     */
+    public function test_square_order_facade_save_location_conflict(): void
+    {
+        $order = $this->data->order->toArray();
+        $product = $this->data->product->toArray();
+        $product['quantity'] = 1;
+        $order['products'] = [$product];
+
+        $this->expectException(MissingPropertyException::class);
+        $this->expectExceptionMessage('Invalid order data');
+        $this->expectExceptionCode(500);
+
+        // Save an order with a non-existing location id - while the location id is set in the order data, causign a
+        // conflict
+        Square::setOrder($order, 123456789)->save();
+    }
+
+    /**
      * Save and charge an order through facade.
      *
      * @return void


### PR DESCRIPTION
### Add location id to the order table

Since all Square orders (created using the Square facade) require a location ID to be added, storing that information will be useful for tracking orders on a per-store basis when integrating this library into other applications.  The following changes apply here:
1. There is a migration to add location_id to the orders table
2. The order of the _saveOrder is slightly altered - first checking if a locationId is present, and then throwing an error if it's not.  This prevents orders with no location ID from being saved, **which may be notably different** from the original use-case under which it was built.
3. This adds the square location env variable to the Order model factory