### PR TITLE
Fixes calculation issues when applying taxes with discounts

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -38,8 +38,6 @@ jobs:
     environment: sandbox
     steps:
       - uses: actions/checkout@v3
-        with:
-          ref: '3.3.x'
 
       # Setup php
       - name: Setup PHP with PECL extension

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,6 +7,7 @@ on:
   pull_request:
     branches:
       - 'master'
+      - 'nikolag_master'
       - '3.1.**'
       - '3.2.**'
       - '3.3.**'

--- a/src/builders/OrderBuilder.php
+++ b/src/builders/OrderBuilder.php
@@ -167,7 +167,7 @@ class OrderBuilder
             // Create taxes Collection
             $orderCopy->taxes = collect([]);
             if ($order->taxes->isNotEmpty()) {
-                $orderCopy->taxes = $this->taxesBuilder->createTaxes($order->taxes->toArray(), $order);
+                $orderCopy->taxes = $this->taxesBuilder->createTaxes($order->taxes->toArray(), Constants::DEDUCTIBLE_SCOPE_ORDER, $order);
             }
             // Create discounts Collection
             $orderCopy->discounts = collect([]);

--- a/src/utils/Util.php
+++ b/src/utils/Util.php
@@ -2,6 +2,7 @@
 
 namespace Nikolag\Square\Utils;
 
+use Exception;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Collection;
 use Nikolag\Square\Models\Product;
@@ -239,13 +240,15 @@ class Util
         $allTaxes = $lineItemTaxes->merge($orderTaxes)->flatten();
 
         // Calculate base total
-        if ($products->isNotEmpty()) {
-            $finalCost = $noDeductiblesCost = $products->map(function ($product) {
-                return $product->price * $product->pivot->quantity;
-            })->pipe(function ($total) {
-                return $total->sum();
-            });
+        if ($products->isEmpty()) {
+            throw new Exception('Total cost cannot be calculated without products.');
         }
+
+        $noDeductiblesCost = $products->map(function ($product) {
+            return $product->price * $product->pivot->quantity;
+        })->pipe(function ($total) {
+            return $total->sum();
+        });
 
         // Calculate cost based on discounts
         $discountCost = $noDeductiblesCost - self::_calculateDiscounts($allDiscounts, $noDeductiblesCost, $products);

--- a/src/utils/Util.php
+++ b/src/utils/Util.php
@@ -137,6 +137,7 @@ class Util
 
             // Calculate and round the product taxes
             $productTaxes = $netPrice * ($tax->percentage / 100);
+
             return round($productTaxes);
         } else {
             return 0;

--- a/src/utils/Util.php
+++ b/src/utils/Util.php
@@ -52,6 +52,30 @@ class Util
     }
 
     /**
+     * Function which calculates the net price by removing any additive taxes to the entire order.
+     *
+     * @param  float  $discountCount
+     * @param  Collection  $inclusiveTaxes
+     * @return float|int
+     */
+    private static function _calculateNetPrice(float $discountCost, Collection $inclusiveTaxes): float|int
+    {
+        // Get all the inclusive taxes
+        $inclusiveTaxPercent = $inclusiveTaxes->filter(function ($tax) {
+            return $tax->type === Constants::TAX_INCLUSIVE;
+        })->map(function ($tax) {
+            return $tax->percentage;
+        })->pipe(function ($total) {
+            return $total->sum();
+        }) / 100;
+
+        // Calculate the net price (amount without inclusive tax)
+        $netPrice = $discountCost / (1 + $inclusiveTaxPercent);
+
+        return $netPrice;
+    }
+
+    /**
      * Function which calculates discounts on order level and where percentage
      * takes over precedence over flat amount.
      *
@@ -92,16 +116,28 @@ class Util
      *
      * @param  $products
      * @param  $tax
+     * @param  Collection  $inclusiveTaxes
+     * @param  Collection  $discounts
      * @return float|int
      */
-    private static function _calculateProductTaxes($products, $tax): float|int
+    private static function _calculateProductTaxes($products, $tax, Collection $inclusiveTaxes, Collection $discounts): float|int
     {
         $product = $products->first(function ($product) use ($tax) {
             return $product->pivot->taxes->contains($tax) || $product->taxes->contains($tax);
         });
 
         if ($product) {
-            return $product->price * $product->pivot->quantity * $tax->percentage / 100;
+            // Get the total product cost (price * quantity)
+            $totalCost = $product->price * $product->pivot->quantity;
+
+            // Calculate order discounts as this will impact the taxes calculated
+            $discountCost = $totalCost - self::_calculateDiscounts($discounts, $totalCost, $products);
+
+            $netPrice = self::_calculateNetPrice($discountCost, $inclusiveTaxes);
+
+            // Calculate and round the product taxes
+            $productTaxes = $netPrice * ($tax->percentage / 100);
+            return round($productTaxes);
         } else {
             return 0;
         }
@@ -110,13 +146,20 @@ class Util
     /**
      * Function which calculates taxes on order level.
      *
-     * @param  float  $noDeductiblesCost
+     * @param  float  $discountCost
      * @param  $tax
+     * @param  Collection  $inclusiveTaxes
      * @return float|int
      */
-    private static function _calculateOrderTaxes(float $noDeductiblesCost, $tax): float|int
+    private static function _calculateOrderTaxes(float $discountCost, $tax, Collection $inclusiveTaxes): float|int
     {
-        return $noDeductiblesCost * $tax->percentage / 100;
+        // Calculate the net price (amount without inclusive tax)
+        $netPrice = self::_calculateNetPrice($discountCost, $inclusiveTaxes);
+
+        // Get the order taxes
+        $orderTaxes = $netPrice * $tax->percentage / 100;
+
+        return round($orderTaxes);
     }
 
     /**
@@ -124,32 +167,45 @@ class Util
      * their scope, type of ADDITIVE.
      *
      * @param  Collection  $taxes
-     * @param  float  $noDeductiblesCost
+     * @param  float  $discountCost
      * @param  Collection  $products
+     * @param  Collection  $discounts
      * @return float|int
      */
-    private static function _calculateTaxes(Collection $taxes, float $noDeductiblesCost, Collection $products): float|int
+    private static function _calculateTaxes(Collection $taxes, float $discountCost, Collection $products, Collection $discounts): float|int
     {
-        $totalTaxes = 0;
-        if ($taxes->isNotEmpty() && $products->isNotEmpty()) {
-            $totalTaxes = $taxes->filter(function ($tax) {
-                return $tax->type === Constants::TAX_ADDITIVE;
-            })->map(function ($taxTwo) use ($products, $noDeductiblesCost) {
-                if ((! $taxTwo->pivot && $taxTwo->scope === Constants::DEDUCTIBLE_SCOPE_PRODUCT) ||
-                    ($taxTwo->pivot && $taxTwo->pivot->scope === Constants::DEDUCTIBLE_SCOPE_PRODUCT)) {
-                    return self::_calculateProductTaxes($products, $taxTwo);
-                } elseif ((! $taxTwo->pivot && $taxTwo->scope === Constants::DEDUCTIBLE_SCOPE_ORDER) ||
-                    ($taxTwo->pivot && $taxTwo->pivot->scope === Constants::DEDUCTIBLE_SCOPE_ORDER)) {
-                    return self::_calculateOrderTaxes($noDeductiblesCost, $taxTwo);
-                }
-
-                return 0;
-            })->pipe(function ($total) {
-                return $total->sum();
-            });
+        // If there are no taxes or products, return 0
+        if ($taxes->isEmpty() || $products->isEmpty()) {
+            return 0;
         }
 
-        return $totalTaxes;
+        // Get all the inclusive taxes
+        $inclusiveTaxes = $taxes->filter(function ($tax) {
+            return $tax->type === Constants::TAX_INCLUSIVE;
+        });
+
+        return $taxes->filter(function ($tax) {
+            return $tax->type === Constants::TAX_ADDITIVE;
+        })->map(function ($taxTwo) use ($products, $discountCost, $discounts, $inclusiveTaxes) {
+            $isProductScope = $taxTwo->scope === Constants::DEDUCTIBLE_SCOPE_PRODUCT;
+            $isOrderScope = $taxTwo->scope === Constants::DEDUCTIBLE_SCOPE_ORDER;
+
+            if ($taxTwo->pivot) {
+                $isProductScope = $taxTwo->pivot->scope === Constants::DEDUCTIBLE_SCOPE_PRODUCT;
+                $isOrderScope = $taxTwo->pivot->scope === Constants::DEDUCTIBLE_SCOPE_ORDER;
+            }
+
+            // Calculate taxes based on scope
+            if ($isProductScope) {
+                $calculatedTaxes = self::_calculateProductTaxes($products, $taxTwo, $inclusiveTaxes, $discounts);
+            } elseif ($isOrderScope) {
+                $calculatedTaxes = self::_calculateOrderTaxes($discountCost, $taxTwo, $inclusiveTaxes);
+            } else {
+                $calculatedTaxes = 0;
+            }
+
+            return $calculatedTaxes;
+        })->sum();
     }
 
     /**
@@ -162,8 +218,6 @@ class Util
      */
     private static function _calculateTotalCost(Collection $discounts, Collection $taxes, Collection $products): float|int
     {
-        $noDeductiblesCost = 0;
-        $finalCost = 0;
         $lineItemDiscounts = collect([]);
         $lineItemTaxes = collect([]);
         $orderDiscounts = collect([]);
@@ -174,12 +228,14 @@ class Util
             $lineItemDiscounts = self::_filterElements(Constants::DEDUCTIBLE_SCOPE_PRODUCT, $discounts);
             $orderDiscounts = self::_filterElements(Constants::DEDUCTIBLE_SCOPE_ORDER, $discounts);
         }
+        $allDiscounts = $lineItemDiscounts->flatten()->merge($orderDiscounts->flatten())->flatten();
 
         // Calculate order level taxes scoped with either ORDER or LINE_ITEM
         if ($taxes->isNotEmpty()) {
             $lineItemTaxes = self::_filterElements(Constants::DEDUCTIBLE_SCOPE_PRODUCT, $taxes);
             $orderTaxes = self::_filterElements(Constants::DEDUCTIBLE_SCOPE_ORDER, $taxes);
         }
+        $allTaxes = $lineItemTaxes->merge($orderTaxes)->flatten();
 
         // Calculate base total
         if ($products->isNotEmpty()) {
@@ -190,8 +246,11 @@ class Util
             });
         }
 
-        $finalCost -= self::_calculateDiscounts($lineItemDiscounts->flatten()->merge($orderDiscounts->flatten())->flatten(), $noDeductiblesCost, $products);
-        $finalCost -= self::_calculateTaxes($lineItemTaxes->merge($orderTaxes)->flatten(), $finalCost, $products);
+        // Calculate cost based on discounts
+        $discountCost = $noDeductiblesCost - self::_calculateDiscounts($allDiscounts, $noDeductiblesCost, $products);
+
+        // Calculate cost based on taxes
+        $finalCost = $discountCost + self::_calculateTaxes($allTaxes, $discountCost, $products, $allDiscounts);
 
         return $finalCost;
     }

--- a/tests/unit/SquareServiceTest.php
+++ b/tests/unit/SquareServiceTest.php
@@ -406,7 +406,7 @@ class SquareServiceTest extends TestCase
             ->charge([
                 'amount' => 935,
                 'source_id' => 'cnon:card-nonce-ok',
-                'location_id' => env('SQUARE_LOCATION')
+                'location_id' => env('SQUARE_LOCATION'),
             ]);
 
         $transaction = $transaction->load('merchant', 'customer');

--- a/tests/unit/SquareServiceTest.php
+++ b/tests/unit/SquareServiceTest.php
@@ -385,7 +385,7 @@ class SquareServiceTest extends TestCase
             ->save();
         $calculatedCost = Util::calculateTotalOrderCostByModel($square->getOrder());
 
-        $this->assertEquals(585, $calculatedCost);
+        $this->assertEquals(707, $calculatedCost);
     }
 
     /**
@@ -402,9 +402,12 @@ class SquareServiceTest extends TestCase
         $productArr['discounts'] = [$productDiscount->toArray()];
         $productArr['taxes'] = [$taxAdditive->toArray()];
 
-        $transaction = Square::setMerchant($this->data->merchant)->setCustomer($this->data->customer)->setOrder($orderArr, env('SQUARE_LOCATION'))->addProduct($productArr)->charge(
-            ['amount' => 750, 'source_id' => 'cnon:card-nonce-ok', 'location_id' => env('SQUARE_LOCATION')]
-        );
+        $transaction = Square::setMerchant($this->data->merchant)->setCustomer($this->data->customer)->setOrder($orderArr, env('SQUARE_LOCATION'))->addProduct($productArr)
+            ->charge([
+                'amount' => 935,
+                'source_id' => 'cnon:card-nonce-ok',
+                'location_id' => env('SQUARE_LOCATION')
+            ]);
 
         $transaction = $transaction->load('merchant', 'customer');
 

--- a/tests/unit/UtilTest.php
+++ b/tests/unit/UtilTest.php
@@ -11,6 +11,7 @@ use Nikolag\Square\Models\Transaction;
 use Nikolag\Square\Tests\Models\Order;
 use Nikolag\Square\Tests\Models\User;
 use Nikolag\Square\Tests\TestCase;
+use Nikolag\Square\Tests\TestDataHolder;
 use Nikolag\Square\Utils\Constants;
 use Nikolag\Square\Utils\Util;
 
@@ -25,6 +26,17 @@ class UtilTest extends TestCase
      * @var Product
      */
     protected $product;
+
+    private TestDataHolder $data;
+
+    /**
+     * @return void
+     */
+    public function setUp(): void
+    {
+        parent::setUp();
+        $this->data = TestDataHolder::make();
+    }
 
     /**
      * Performs assertions shared by all tests of a test case.
@@ -85,6 +97,55 @@ class UtilTest extends TestCase
         $actual = Util::calculateTotalOrderCostByModel($square->getOrder());
 
         $this->assertEquals($expected, $actual, 'Util::calculateTotalOrderCost didn\'t calculate properly.');
+    }
+
+    /**
+     * Test if the total calculation is done right.
+     *
+     * @return void
+     */
+    public function test_calculate_total_order_with_product_discount(): void
+    {
+        extract($this->data->modify(prodFac: 'make', prodDiscFac: 'make', orderDisFac: 'make', taxAddFac: 'make'));
+        $orderArr = $this->data->order->toArray();
+        $orderArr['discounts'] = [$orderDiscount->toArray()];
+        $productArr = $product->toArray();
+        $productArr['discounts'] = [$productDiscount->toArray()];
+        $productArr['taxes'] = [$taxAdditive->toArray()];
+
+        // Create a square order with all sorts of discounts and taxes.
+        $square = Square::setMerchant($this->data->merchant)
+            ->setCustomer($this->data->customer)
+            ->setOrder($orderArr, env('SQUARE_LOCATION'))
+            ->addProduct($productArr)
+            ->save();
+
+        // The expected total is 935.
+        $this->assertEquals(935, Util::calculateTotalOrderCostByModel($square->getOrder()));
+    }
+
+    /**
+     * Test if the total calculation is done right.
+     *
+     * @return void
+     */
+    public function test_calculate_total_order_with_order_discount(): void
+    {
+        extract($this->data->modify(prodFac: 'make', prodDiscFac: 'make', orderDisFac: 'make', taxAddFac: 'make'));
+        $orderArr = $this->data->order->toArray();
+        $orderArr['discounts'] = [$orderDiscount->toArray()];
+        $orderArr['taxes'] = [$taxAdditive->toArray()];
+        $productArr = $product->toArray();
+
+        // Create a square order with all sorts of discounts and taxes.
+        $square = Square::setMerchant($this->data->merchant)
+            ->setCustomer($this->data->customer)
+            ->setOrder($orderArr, env('SQUARE_LOCATION'))
+            ->addProduct($productArr)
+            ->save();
+
+        // The expected total is 990.
+        $this->assertEquals(990, Util::calculateTotalOrderCostByModel($square->getOrder()));
     }
 
     /**

--- a/tests/unit/UtilTest.php
+++ b/tests/unit/UtilTest.php
@@ -2,6 +2,7 @@
 
 namespace Nikolag\Square\Tests\Unit;
 
+use Exception;
 use Nikolag\Square\Facades\Square;
 use Nikolag\Square\Models\Customer;
 use Nikolag\Square\Models\Discount;
@@ -146,6 +147,20 @@ class UtilTest extends TestCase
 
         // The expected total is 990.
         $this->assertEquals(990, Util::calculateTotalOrderCostByModel($square->getOrder()));
+    }
+
+    /**
+     * Test missing attributes for the calculation.
+     *
+     * @return void
+     */
+    public function test_calculate_total_order_cost_missing_data(): void
+    {
+        $this->expectException(Exception::class);
+        $this->expectExceptionMessage('Total cost cannot be calculated without products.');
+
+        // Run the calculation with missing products
+        Util::calculateTotalOrderCostByModel($this->order);
     }
 
     /**


### PR DESCRIPTION
### Tax Calculation Fixes

When discounts are added to individual items or entire orders, it does not match the value that Square expects in order to create a transaction via their APIs.  This updates the calculation so that taxes are properly calculated, taking into account both additive and inclusive taxes, applying the discount before the taxes.

It also fixes a bug where the `OrderBuilder` was not properly passing in the tax scope when creating the taxes collection.