### PR TITLE
Adds Square API error to save exceptions

### DIFF
--- a/src/SquareService.php
+++ b/src/SquareService.php
@@ -251,7 +251,8 @@ class SquareService extends CorePaymentService implements SquareServiceContract
             try {
                 $this->_saveCustomer();
             } catch (Exception $e) {
-                throw new Exception('There was an error with the api request', 500, $e);
+                $apiErrorMessage = $e->getMessage();
+                throw new Exception('There was an error with the api request: '.$apiErrorMessage, 500, $e);
             }
             // Save customer into the table for further use
             $transaction->customer()->associate($this->getCustomer());
@@ -280,7 +281,8 @@ class SquareService extends CorePaymentService implements SquareServiceContract
             } catch (InvalidSquareOrderException $e) {
                 throw new MissingPropertyException('Required column is missing from the table', 500, $e);
             } catch (Exception $e) {
-                throw new Exception('There was an error with the api request', 500, $e);
+                $apiErrorMessage = $e->getMessage();
+                throw new Exception('There was an error with the api request: '.$apiErrorMessage, 500, $e);
             }
         }
         $transaction->save();

--- a/src/SquareService.php
+++ b/src/SquareService.php
@@ -197,7 +197,8 @@ class SquareService extends CorePaymentService implements SquareServiceContract
         } catch (InvalidSquareOrderException $e) {
             throw new MissingPropertyException('Required column is missing from the table', 500, $e);
         } catch (Exception|ApiException $e) {
-            throw new Exception('There was an error with the api request', 500, $e);
+            $apiErrorMessage = $e->getMessage();
+            throw new Exception('There was an error with the api request: '.$apiErrorMessage, 500, $e);
         }
 
         return $this;


### PR DESCRIPTION
When troubleshooting Square API error message, the current exception handling outputs an API error like so:
Nikolag\Square\Exception 

  There was an error with the api request

  at vendor/nikolag/laravel-square/src/SquareService.php:516
    512▕                 throw new MissingPropertyException('Required field is missing', 500, $e);
    513▕             } catch (InvalidSquareOrderException $e) {
    514▕                 throw new MissingPropertyException('Invalid order data', 500, $e);
    515▕             } catch (Exception $e) {
  ➜ 516▕                 throw new Exception('There was an error with the api request', 500, $e);
    517▕             }
    518▕         }
    519▕         $transaction->save();
    520▕ 


This update will add the details that are parsed via the `_handleApiResponseErrors` function to the error message:

  Nikolag\Square\Exception 

  There was an error with the api request: INVALID_REQUEST_ERROR: `Japan` is not a valid enum value for `Country` (line 1, character 786)

  at vendor/nikolag/laravel-square/src/SquareService.php:518
    514▕             } catch (InvalidSquareOrderException $e) {
    515▕                 throw new MissingPropertyException('Invalid order data', 500, $e);
    516▕             } catch (Exception $e) {
    517▕                 $apiErrorMessage = $e->getMessage();
  ➜ 518▕                 throw new Exception('There was an error with the api request: '.$apiErrorMessage, 500, $e);
    519▕             }
    520▕         }
    521▕         $transaction->save();
    522▕ 
