### PR TITLE
Adds list catalog method to Square facade

### DIFF
--- a/src/SquareConfig.php
+++ b/src/SquareConfig.php
@@ -4,6 +4,7 @@ namespace Nikolag\Square;
 
 use Nikolag\Core\CoreConfig;
 use Nikolag\Core\Exceptions\InvalidConfigurationException;
+use Square\Apis\CatalogApi;
 use Square\Apis\CustomersApi;
 use Square\Apis\LocationsApi;
 use Square\Apis\OrdersApi;
@@ -37,7 +38,18 @@ class SquareConfig extends CoreConfig
     }
 
     /**
+     * Api for catalog.
+     *
+     * @return CatalogApi
+     */
+    public function catalogAPI(): CatalogApi
+    {
+        return $this->squareClient->getCatalogApi();
+    }
+
+    /**
      * Api for locations.
+     *
      *
      * @return LocationsApi
      */
@@ -58,6 +70,9 @@ class SquareConfig extends CoreConfig
 
     /**
      * Api for transactions.
+     *
+     * @deprecated cf. https://developer.squareup.com/docs/build-basics/api-lifecycle#deprecated
+     * @see https://developer.squareup.com/docs/payments-api/migrate-from-transactions-api
      *
      * @return TransactionsApi
      */

--- a/src/SquareService.php
+++ b/src/SquareService.php
@@ -2,6 +2,7 @@
 
 namespace Nikolag\Square;
 
+use Illuminate\Support\Arr;
 use Nikolag\Core\Abstracts\CorePaymentService;
 use Nikolag\Square\Builders\CustomerBuilder;
 use Nikolag\Square\Builders\OrderBuilder;
@@ -89,17 +90,18 @@ class SquareService extends CorePaymentService implements SquareServiceContract
     /**
      * Lists the entire catalog.
      *
-     * @param string $types The types of objects to list.
+     * @param array<\Square\Models\CatalogObjectType> $types The types of objects to list.
      *
      * @return array<\Square\Models\CatalogObject> The catalog items.
      *
      * @throws ApiException
      */
-    public function listCatalog(?string $types = null): array
+    public function listCatalog(array $typesFilter = []): array
     {
+        $types = !empty($typesFilter) ? Arr::join($typesFilter, ',') : null;
+
         $catalogItems = [];
         $cursor       = null;
-
         do {
             $apiResponse = $this->config->catalogApi()->listCatalog($cursor, $types);
 
@@ -109,7 +111,7 @@ class SquareService extends CorePaymentService implements SquareServiceContract
                 $catalogItems = array_merge($catalogItems, $results->getObjects() ?? []);
                 $cursor       = $results->getCursor();
             } else {
-                throw $this->handleApiResponseErrors($apiResponse);
+                throw $this->_handleApiResponseErrors($apiResponse);
             }
         } while ($cursor);
 

--- a/src/SquareService.php
+++ b/src/SquareService.php
@@ -87,6 +87,36 @@ class SquareService extends CorePaymentService implements SquareServiceContract
     }
 
     /**
+     * Lists the entire catalog.
+     *
+     * @param string $types The types of objects to list.
+     *
+     * @return array<\Square\Models\CatalogObject> The catalog items.
+     *
+     * @throws ApiException
+     */
+    public function listCatalog(?string $types = null): array
+    {
+        $catalogItems = [];
+        $cursor       = null;
+
+        do {
+            $apiResponse = $this->config->catalogApi()->listCatalog($cursor, $types);
+
+            if ($apiResponse->isSuccess()) {
+                /** @var ListCatalogResponse $results */
+                $results      = $apiResponse->getResult();
+                $catalogItems = array_merge($catalogItems, $results->getObjects() ?? []);
+                $cursor       = $results->getCursor();
+            } else {
+                throw $this->handleApiResponseErrors($apiResponse);
+            }
+        } while ($cursor);
+
+        return $catalogItems;
+    }
+
+    /**
      * Save a customer.
      *
      * @return void

--- a/src/facades/Square.php
+++ b/src/facades/Square.php
@@ -17,6 +17,7 @@ use Square\Models\ListPaymentsResponse;
  * @method static mixed getMerchant()
  * @method static SquareServiceContract setMerchant($merchant)
  * @method static mixed getOrder()
+ * @method static SquareService listCatalog()
  * @method static SquareServiceContract addProduct($product, int $quantity, string $currency = 'USD')
  * @method static SquareServiceContract setOrder($order, string $locationId, string $currency = 'USD')
  *

--- a/src/facades/Square.php
+++ b/src/facades/Square.php
@@ -17,7 +17,7 @@ use Square\Models\ListPaymentsResponse;
  * @method static mixed getMerchant()
  * @method static SquareServiceContract setMerchant($merchant)
  * @method static mixed getOrder()
- * @method static SquareService listCatalog()
+ * @method static SquareService listCatalog(array $types = [])
  * @method static SquareServiceContract addProduct($product, int $quantity, string $currency = 'USD')
  * @method static SquareServiceContract setOrder($order, string $locationId, string $currency = 'USD')
  *

--- a/tests/unit/SquareServiceTest.php
+++ b/tests/unit/SquareServiceTest.php
@@ -15,6 +15,8 @@ use Nikolag\Square\Tests\TestCase;
 use Nikolag\Square\Tests\TestDataHolder;
 use Nikolag\Square\Utils\Constants;
 use Nikolag\Square\Utils\Util;
+use Square\Models\CatalogObject;
+use Square\Models\CatalogObjectType;
 
 class SquareServiceTest extends TestCase
 {
@@ -489,6 +491,40 @@ class SquareServiceTest extends TestCase
         $catalog = Square::listCatalog();
 
         $this->assertNotNull($catalog);
-        $this->assertInstanceOf('\Square\Models\ListCatalogResponse', $catalog);
+        $this->assertIsArray($catalog);
+        foreach ($catalog as $item) {
+            $this->assertInstanceOf('\Square\Models\CatalogObject', $item);
+        }
+    }
+
+    /**
+     * Ensures filtering the catalog by type is supported
+     *
+     * @return void
+     */
+    public function test_square_list_catalog_by_type(): void
+    {
+        $catalogItems = Square::listCatalog([CatalogObjectType::ITEM]);
+
+        $this->assertNotNull($catalogItems);
+        $this->assertIsArray($catalogItems);
+        foreach ($catalogItems as $item) {
+            $this->assertInstanceOf(CatalogObject::class, $item);
+            $this->assertEquals('ITEM', $item->getType());
+        }
+    }
+
+    /**
+     * Ensures an exception is thrown when retrieving non-standard catalog information.
+     *
+     * @return void
+     */
+    public function test_square_list_catalog_unsupported_type(): void
+    {
+        $this->expectException(Exception::class);
+        $this->expectExceptionMessage('INVALID_REQUEST_ERROR: Unknown object type "UNSUPPORTED_ITEM"');
+        $this->expectExceptionCode(400);
+
+        Square::listCatalog(['unsupported_item']);
     }
 }

--- a/tests/unit/SquareServiceTest.php
+++ b/tests/unit/SquareServiceTest.php
@@ -478,4 +478,17 @@ class SquareServiceTest extends TestCase
         $this->assertEquals(Constants::DEDUCTIBLE_SCOPE_ORDER,
             $transaction->order->discounts->where('name', $orderDiscount->name)->first()->pivot->scope, 'Discount scope is not \'ORDER\'');
     }
+
+    /**
+     * Tests retrieving catalog information.
+     *
+     * @return void
+     */
+    public function test_square_list_catalog(): void
+    {
+        $catalog = Square::listCatalog();
+
+        $this->assertNotNull($catalog);
+        $this->assertInstanceOf('\Square\Models\ListCatalogResponse', $catalog);
+    }
 }


### PR DESCRIPTION
This adds a method to retrieve catalog data from the Catalog API, allowing users to pass in non (returns all) one or many catalog types.  

There are three tests added:
1. One that confirm the entire catalog can be retrieved
2. One that confirms the request can be filtered to specific items
3. One that validates exceptions will be thrown when filtering incorrect items.


**Usage**
This new method can be used by calling:
`Square::listCatalog()` 
and optionally can take in an array of types:
`Square::listCatalog(['ITEM'])` 

Although it's recommended you use the `CatalogObjectType` model to prevent issues that arise when using strings:
```
use Square\Models\CatalogObjectType;

$catalogItems = Square::listCatalog([CatalogObjectType::ITEM]);
```