### PR TITLE
Update Square library to v40.0.0.20250123

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
         "illuminate/filesystem": "11.x",
         "illuminate/support": "11.x",
         "nikolag/core": "2.9.x",
-        "square/square": "29.0.0.20230720"
+        "square/square": "40.0.0.20250123"
     },
     "require-dev": {
         "fakerphp/faker": "^1.13",


### PR DESCRIPTION
@NikolaGavric94  I've just realized that the 3.4 branch indicates that it's been updated to use the `40.0.0.20250123` version of the Square PHP SDK, but it's still using `29.0.0.20230720`.  This updates that to align with the correct version.