### PR TITLE
Encrypts Webhook Subscription Signature Keys

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -70,10 +70,16 @@ jobs:
           composer install --no-interaction --no-cache
           composer dump-autoload
 
+      # Generate application key
+      - name: Generate APP_KEY
+        run: |
+          echo "APP_KEY=$(php artisan key:generate --show)" >> $GITHUB_ENV
+
       # Run phpunit tests
       - name: Run tests
         run: vendor/bin/phpunit --migrate-configuration && vendor/bin/phpunit --coverage-text --coverage-clover build/logs/clover.xml
         env:
+          APP_KEY: ${{ env.APP_KEY }}
           SQUARE_ORDER_NAMESPACE: ${{ secrets.SQUARE_ORDER_NAMESPACE }}
           SQUARE_USER_NAMESPACE: ${{ secrets.SQUARE_USER_NAMESPACE }}
           SQUARE_APPLICATION_ID: ${{ secrets.SQUARE_APPLICATION_ID }}

--- a/src/database/migrations/2025_08_20_131705_alter_signature_key_to_text.php
+++ b/src/database/migrations/2025_08_20_131705_alter_signature_key_to_text.php
@@ -3,6 +3,9 @@
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Crypt;
+use Illuminate\Support\Facades\Log;
 
 return new class extends Migration
 {
@@ -11,9 +14,30 @@ return new class extends Migration
      */
     public function up(): void
     {
+        // Step 1: Store existing unencrypted data
+        $existingData = DB::table('nikolag_webhook_subscriptions')
+            ->select(['id', 'signature_key'])
+            ->get();
+
+        // Step 2: Change column type to accommodate encrypted data
         Schema::table('nikolag_webhook_subscriptions', function (Blueprint $table) {
             $table->text('signature_key')->change();
         });
+
+        // Step 3: Encrypt existing unencrypted signature keys
+        foreach ($existingData as $record) {
+            if ($record->signature_key) {
+                // Only encrypt if it's not already encrypted
+                // Laravel's encrypted cast produces base64 strings that start with specific patterns
+                if (!$this->isAlreadyEncrypted($record->signature_key)) {
+                    $encryptedKey = Crypt::encryptString($record->signature_key);
+
+                    DB::table('nikolag_webhook_subscriptions')
+                        ->where('id', $record->id)
+                        ->update(['signature_key' => $encryptedKey]);
+                }
+            }
+        }
     }
 
     /**
@@ -21,8 +45,60 @@ return new class extends Migration
      */
     public function down(): void
     {
+        // Step 1: Decrypt existing encrypted data before changing column type
+        $existingData = DB::table('nikolag_webhook_subscriptions')
+            ->select(['id', 'signature_key'])
+            ->get();
+
+        // Step 2: Attempt to decrypt encrypted signature keys
+        foreach ($existingData as $record) {
+            if ($record->signature_key && $this->isAlreadyEncrypted($record->signature_key)) {
+                try {
+                    $decryptedKey = Crypt::decryptString($record->signature_key);
+
+                    // Ensure the decrypted key fits in a string column (255 chars max)
+                    if (strlen($decryptedKey) <= 255) {
+                        DB::table('nikolag_webhook_subscriptions')
+                            ->where('id', $record->id)
+                            ->update(['signature_key' => $decryptedKey]);
+                    } else {
+                        // Log warning - signature key too long for string column
+                        Log::warning("Webhook signature key for ID {$record->id} too long for string column during rollback");
+                    }
+                } catch (Exception $e) {
+                    // Log decryption failure but continue migration
+                    Log::warning("Failed to decrypt signature key for webhook subscription ID {$record->id}: " . $e->getMessage());
+                }
+            }
+        }
+
+        // Step 3: Change column type back to string
         Schema::table('nikolag_webhook_subscriptions', function (Blueprint $table) {
             $table->string('signature_key')->change();
         });
+    }
+
+    /**
+     * Check if a value appears to be already encrypted by Laravel's Crypt class.
+     *
+     * @param string $value
+     * @return bool
+     */
+    private function isAlreadyEncrypted(string $value): bool
+    {
+        // Laravel's encrypted values are base64 encoded JSON strings
+        // They typically start with "eyJ" when base64 decoded starts with "{"
+        if (strlen($value) < 20) {
+            return false; // Too short to be encrypted
+        }
+
+        // Try to decode as base64 and check if it's a JSON structure
+        $decoded = base64_decode($value, true);
+        if ($decoded === false) {
+            return false;
+        }
+
+        $json = json_decode($decoded, true);
+        return $json !== null && isset($json['iv']) && isset($json['value']) && isset($json['mac']);
     }
 };

--- a/src/database/migrations/2025_08_20_131705_alter_signature_key_to_text.php
+++ b/src/database/migrations/2025_08_20_131705_alter_signature_key_to_text.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('nikolag_webhook_subscriptions', function (Blueprint $table) {
+            $table->text('signature_key')->change();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('nikolag_webhook_subscriptions', function (Blueprint $table) {
+            $table->string('signature_key')->change();
+        });
+    }
+};

--- a/src/models/WebhookSubscription.php
+++ b/src/models/WebhookSubscription.php
@@ -42,6 +42,7 @@ class WebhookSubscription extends Model
      */
     protected $casts = [
         'event_types' => 'array',
+        'signature_key' => 'encrypted',
         'is_enabled' => 'boolean',
         'is_active' => 'boolean',
         'last_tested_at' => 'datetime',

--- a/tests/unit/SquareServiceWebhookTest.php
+++ b/tests/unit/SquareServiceWebhookTest.php
@@ -258,10 +258,14 @@ class SquareServiceWebhookTest extends TestCase
         $this->assertEquals('wh_recreate_test_789', $webhookSubscription->square_id);
         $this->assertEquals($signatureKey, $webhookSubscription->signature_key);
 
+        // Verify encryption
+        $encryptedKey = $webhookSubscription->getRawOriginal('signature_key');
+        $this->assertNotEquals($encryptedKey, $webhookSubscription->signature_key);
+
         $this->assertDatabaseHas('nikolag_webhook_subscriptions', [
             'square_id' => $webhookSubscription->square_id,
             'name' => 'Webhook for Recreate Test',
-            'signature_key' => $signatureKey
+            'signature_key' => $encryptedKey
         ]);
 
         // Step 2: Delete the local WebhookSubscription record from database


### PR DESCRIPTION
Adds encryption to signature keys so they are not visible in plain text at rest in the database.

There is a migration that will also encrypt any un-encrypted data that currently exists as used in previous versions of this package.