### PR TITLE
Creates new HasAddress trait

### DIFF
--- a/src/builders/SquareRequestBuilder.php
+++ b/src/builders/SquareRequestBuilder.php
@@ -91,6 +91,11 @@ class SquareRequestBuilder
         $request->setReferenceId($customer->owner_id);
         $request->setNote($customer->note);
 
+        // Add address if customer has an address relationship
+        if ($customer->hasAddress()) {
+            $request->setAddress($customer->address->toSquareAddress());
+        }
+
         return $request;
     }
 

--- a/src/database/factories/ModelFactory.php
+++ b/src/database/factories/ModelFactory.php
@@ -3,6 +3,7 @@
 use Illuminate\Database\Eloquent\Factory as EloquentFactory;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Str;
+use Nikolag\Square\Models\Address;
 use Nikolag\Square\Tests\Models\Order;
 use Nikolag\Square\Tests\Models\User;
 use Nikolag\Square\Utils\Constants;
@@ -88,6 +89,24 @@ $factory->define(Constants::CUSTOMER_NAMESPACE, function (Faker\Generator $faker
         'email' => $faker->unique()->companyEmail,
         'phone' => $faker->unique()->tollFreePhoneNumber,
         'note' => $faker->unique()->paragraph(5),
+    ];
+});
+
+/* @var \Illuminate\Database\Eloquent\Factory $factory */
+$factory->define(Address::class, function (Faker\Generator $faker) {
+    return [
+        'address_line_1' => $faker->streetAddress,
+        'address_line_2' => $faker->optional(0.3)->secondaryAddress,
+        'address_line_3' => $faker->optional(0.1)->buildingNumber,
+        'locality' => $faker->city,
+        'administrative_district_level_1' => $faker->stateAbbr,
+        'administrative_district_level_2' => $faker->optional(0.2)->word,
+        'administrative_district_level_3' => $faker->optional(0.1)->word,
+        'sublocality' => $faker->optional(0.2)->streetName,
+        'sublocality_2' => $faker->optional(0.1)->word,
+        'sublocality_3' => $faker->optional(0.1)->word,
+        'postal_code' => $faker->postcode,
+        'country' => 'US',
     ];
 });
 

--- a/src/database/migrations/2025_12_23_145950_create_nikolag_addresses_table.php
+++ b/src/database/migrations/2025_12_23_145950_create_nikolag_addresses_table.php
@@ -1,0 +1,56 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * Create nikolag_addresses table for polymorphic address storage.
+ */
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('nikolag_addresses', function (Blueprint $table) {
+            $table->id();
+
+            // Polymorphic relationship fields (nullable for flexibility)
+            $table->nullableMorphs('addressable');
+
+            // Address fields following Square's Address object structure
+            $table->string('address_line_1', 500)->nullable();
+            $table->string('address_line_2', 500)->nullable();
+            $table->string('address_line_3', 500)->nullable();
+            $table->string('locality', 255)->nullable()->comment('City');
+            $table->string('administrative_district_level_1', 255)->nullable()->comment('State/Province');
+            $table->string('administrative_district_level_2', 255)->nullable()->comment('County/District');
+            $table->string('administrative_district_level_3', 255)->nullable()->comment('Sub-district');
+            $table->string('sublocality', 255)->nullable()->comment('Neighborhood');
+            $table->string('sublocality_2', 255)->nullable();
+            $table->string('sublocality_3', 255)->nullable();
+            $table->string('postal_code', 20)->nullable()->comment('ZIP/Postal code');
+            $table->string('country', 2)->nullable()->comment('ISO 3166-1-alpha-2 country code');
+
+            $table->timestamps();
+
+            // Indexes for common queries
+            $table->index('country');
+            $table->index('postal_code');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::dropIfExists('nikolag_addresses');
+    }
+};

--- a/src/models/Address.php
+++ b/src/models/Address.php
@@ -5,6 +5,7 @@ namespace Nikolag\Square\Models;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\MorphTo;
 use Square\Models\Address as SquareAddress;
+use Square\Models\Builders\AddressBuilder;
 
 class Address extends Model
 {
@@ -59,31 +60,30 @@ class Address extends Model
     /**
      * Convert address fields to Square Address object.
      *
-     * @return \Square\Models\Address
+     * @return SquareAddress
      */
     public function toSquareAddress(): SquareAddress
     {
-        $address = new SquareAddress();
-        $address->setAddressLine1($this->address_line_1);
-        $address->setAddressLine2($this->address_line_2);
-        $address->setAddressLine3($this->address_line_3);
-        $address->setLocality($this->locality);
-        $address->setAdministrativeDistrictLevel1($this->administrative_district_level_1);
-        $address->setAdministrativeDistrictLevel2($this->administrative_district_level_2);
-        $address->setAdministrativeDistrictLevel3($this->administrative_district_level_3);
-        $address->setSublocality($this->sublocality);
-        $address->setSublocality2($this->sublocality_2);
-        $address->setSublocality3($this->sublocality_3);
-        $address->setPostalCode($this->postal_code);
-        $address->setCountry($this->country);
-
-        return $address;
+        return AddressBuilder::init()
+        ->addressLine1($this->address_line_1)
+        ->addressLine2($this->address_line_2)
+        ->addressLine3($this->address_line_3)
+        ->locality($this->locality)
+        ->administrativeDistrictLevel1($this->administrative_district_level_1)
+        ->administrativeDistrictLevel2($this->administrative_district_level_2)
+        ->administrativeDistrictLevel3($this->administrative_district_level_3)
+        ->sublocality($this->sublocality)
+        ->sublocality2($this->sublocality_2)
+        ->sublocality3($this->sublocality_3)
+        ->postalCode($this->postal_code)
+        ->country($this->country)
+        ->build();
     }
 
     /**
      * Create an Address model from Square Address object.
      *
-     * @param  \Square\Models\Address  $squareAddress
+     * @param  SquareAddress  $squareAddress
      * @return static
      */
     public static function fromSquareAddress(SquareAddress $squareAddress): static

--- a/src/models/Address.php
+++ b/src/models/Address.php
@@ -1,0 +1,130 @@
+<?php
+
+namespace Nikolag\Square\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\MorphTo;
+use Square\Models\Address as SquareAddress;
+
+class Address extends Model
+{
+    /**
+     * The table associated with the model.
+     *
+     * @var string
+     */
+    protected $table = 'nikolag_addresses';
+
+    /**
+     * The attributes that are mass assignable.
+     *
+     * @var array
+     */
+    protected $fillable = [
+        'address_line_1',
+        'address_line_2',
+        'address_line_3',
+        'locality',
+        'administrative_district_level_1',
+        'administrative_district_level_2',
+        'administrative_district_level_3',
+        'sublocality',
+        'sublocality_2',
+        'sublocality_3',
+        'postal_code',
+        'country',
+    ];
+
+    /**
+     * The attributes that aren't mass assignable.
+     *
+     * @var array
+     */
+    protected $guarded = [
+        'id',
+        'addressable_type',
+        'addressable_id',
+    ];
+
+    /**
+     * Get the parent addressable model (Customer, Recipient, etc.).
+     *
+     * @return \Illuminate\Database\Eloquent\Relations\MorphTo
+     */
+    public function addressable(): MorphTo
+    {
+        return $this->morphTo();
+    }
+
+    /**
+     * Convert address fields to Square Address object.
+     *
+     * @return \Square\Models\Address
+     */
+    public function toSquareAddress(): SquareAddress
+    {
+        $address = new SquareAddress();
+        $address->setAddressLine1($this->address_line_1);
+        $address->setAddressLine2($this->address_line_2);
+        $address->setAddressLine3($this->address_line_3);
+        $address->setLocality($this->locality);
+        $address->setAdministrativeDistrictLevel1($this->administrative_district_level_1);
+        $address->setAdministrativeDistrictLevel2($this->administrative_district_level_2);
+        $address->setAdministrativeDistrictLevel3($this->administrative_district_level_3);
+        $address->setSublocality($this->sublocality);
+        $address->setSublocality2($this->sublocality_2);
+        $address->setSublocality3($this->sublocality_3);
+        $address->setPostalCode($this->postal_code);
+        $address->setCountry($this->country);
+
+        return $address;
+    }
+
+    /**
+     * Create an Address model from Square Address object.
+     *
+     * @param  \Square\Models\Address  $squareAddress
+     * @return static
+     */
+    public static function fromSquareAddress(SquareAddress $squareAddress): static
+    {
+        return new static([
+            'address_line_1' => $squareAddress->getAddressLine1(),
+            'address_line_2' => $squareAddress->getAddressLine2(),
+            'address_line_3' => $squareAddress->getAddressLine3(),
+            'locality' => $squareAddress->getLocality(),
+            'administrative_district_level_1' => $squareAddress->getAdministrativeDistrictLevel1(),
+            'administrative_district_level_2' => $squareAddress->getAdministrativeDistrictLevel2(),
+            'administrative_district_level_3' => $squareAddress->getAdministrativeDistrictLevel3(),
+            'sublocality' => $squareAddress->getSublocality(),
+            'sublocality_2' => $squareAddress->getSublocality2(),
+            'sublocality_3' => $squareAddress->getSublocality3(),
+            'postal_code' => $squareAddress->getPostalCode(),
+            'country' => $squareAddress->getCountry(),
+        ]);
+    }
+
+    /**
+     * Update address fields from Square Address object.
+     *
+     * @param  \Square\Models\Address  $squareAddress
+     * @return void
+     */
+    public function updateFromSquareAddress(SquareAddress $squareAddress): void
+    {
+        $this->fill([
+            'address_line_1' => $squareAddress->getAddressLine1(),
+            'address_line_2' => $squareAddress->getAddressLine2(),
+            'address_line_3' => $squareAddress->getAddressLine3(),
+            'locality' => $squareAddress->getLocality(),
+            'administrative_district_level_1' => $squareAddress->getAdministrativeDistrictLevel1(),
+            'administrative_district_level_2' => $squareAddress->getAdministrativeDistrictLevel2(),
+            'administrative_district_level_3' => $squareAddress->getAdministrativeDistrictLevel3(),
+            'sublocality' => $squareAddress->getSublocality(),
+            'sublocality_2' => $squareAddress->getSublocality2(),
+            'sublocality_3' => $squareAddress->getSublocality3(),
+            'postal_code' => $squareAddress->getPostalCode(),
+            'country' => $squareAddress->getCountry(),
+        ]);
+    }
+}

--- a/src/models/Customer.php
+++ b/src/models/Customer.php
@@ -4,10 +4,13 @@ namespace Nikolag\Square\Models;
 
 use DateTimeInterface;
 use Nikolag\Core\Models\Customer as CoreCustomer;
+use Nikolag\Square\Traits\HasAddress;
 use Nikolag\Square\Utils\Constants;
 
 class Customer extends CoreCustomer
 {
+    use HasAddress;
+
     /**
      * The model's attributes.
      *

--- a/src/traits/HasAddress.php
+++ b/src/traits/HasAddress.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace Nikolag\Square\Traits;
+
+use Illuminate\Database\Eloquent\Relations\MorphOne;
+use Nikolag\Square\Models\Address;
+use Square\Models\Address as SquareAddress;
+
+trait HasAddress
+{
+    /**
+     * Get the address relationship.
+     *
+     * @return MorphOne
+     */
+    public function address(): MorphOne
+    {
+        return $this->morphOne(Address::class, 'addressable');
+    }
+
+    /**
+     * Check if the model has an address.
+     *
+     * @return bool
+     */
+    public function hasAddress(): bool
+    {
+        return $this->address()->exists();
+    }
+
+    /**
+     * Get the address as a Square Address object.
+     *
+     * @return SquareAddress|null
+     */
+    public function getSquareAddress(): ?SquareAddress
+    {
+        if (! $this->address) {
+            return null;
+        }
+
+        return $this->address->toSquareAddress();
+    }
+
+    /**
+     * Create or update address from Square Address object.
+     *
+     * @param  SquareAddress  $squareAddress
+     * @return Address
+     */
+    public function syncAddressFromSquare(SquareAddress $squareAddress): Address
+    {
+        $address = $this->address()->firstOrNew([]);
+        $address->updateFromSquareAddress($squareAddress);
+        $this->address()->save($address);
+
+        return $address;
+    }
+}

--- a/tests/TestDataHolder.php
+++ b/tests/TestDataHolder.php
@@ -2,6 +2,7 @@
 
 namespace Nikolag\Square\Tests;
 
+use Nikolag\Square\Models\Address;
 use Nikolag\Square\Models\Customer;
 use Nikolag\Square\Models\Discount;
 use Nikolag\Square\Models\Product;
@@ -16,7 +17,8 @@ class TestDataHolder
                                 public ?Customer $customer,
                                 public ?User $merchant,
                                 public ?Tax $tax,
-                                public ?Discount $discount)
+                                public ?Discount $discount,
+                                public ?Address $address)
     {
     }
 
@@ -27,7 +29,8 @@ class TestDataHolder
             factory(Customer::class)->make(),
             factory(User::class)->make(),
             factory(Tax::class)->make(),
-            factory(Discount::class)->states('AMOUNT_ONLY')->make());
+            factory(Discount::class)->states('AMOUNT_ONLY')->make(),
+            factory(Address::class)->make());
     }
 
     public static function create(): self
@@ -37,7 +40,8 @@ class TestDataHolder
             factory(Customer::class)->create(),
             factory(User::class)->create(),
             factory(Tax::class)->create(),
-            factory(Discount::class)->states('AMOUNT_ONLY')->create());
+            factory(Discount::class)->states('AMOUNT_ONLY')->create(),
+            factory(Address::class)->create());
     }
 
     public function modify(string $prodFac = 'create',
@@ -45,7 +49,8 @@ class TestDataHolder
                            string $orderDisFac = 'create',
                            string $orderDiscFixFac = 'create',
                            string $taxAddFac = 'create',
-                           string $taxIncFac = 'create')
+                           string $taxIncFac = 'create',
+                           string $addressFac = 'create')
     {
         $product = factory(Product::class)->{$prodFac}([
             'price' => 1000,
@@ -65,7 +70,8 @@ class TestDataHolder
         $taxInclusive = factory(Tax::class)->states('INCLUSIVE')->{$taxIncFac}([
             'percentage' => 15.0,
         ]);
+        $address = factory(Address::class)->{$addressFac}();
 
-        return compact('product', 'productDiscount', 'orderDiscount', 'orderDiscountFixed', 'taxAdditive', 'taxInclusive');
+        return compact('product', 'productDiscount', 'orderDiscount', 'orderDiscountFixed', 'taxAdditive', 'taxInclusive', 'address');
     }
 }

--- a/tests/unit/AddressTest.php
+++ b/tests/unit/AddressTest.php
@@ -1,0 +1,235 @@
+<?php
+
+namespace Nikolag\Square\Tests\Unit;
+
+use Nikolag\Square\Models\Address;
+use Nikolag\Square\Models\Customer;
+use Nikolag\Square\Models\Recipient;
+use Nikolag\Square\Tests\TestCase;
+use Nikolag\Square\Tests\TestDataHolder;
+use Square\Models\Address as SquareAddress;
+
+class AddressTest extends TestCase
+{
+    private TestDataHolder $data;
+    private Recipient $recipient;
+
+    /**
+     * @return void
+     */
+    public function setUp(): void
+    {
+        parent::setUp();
+        $this->data = TestDataHolder::create();
+    }
+
+    /**
+     * Address creation test.
+     *
+     * @return void
+     */
+    public function test_address_make(): void
+    {
+        $address = factory(Address::class)->create();
+
+        $this->assertNotNull($address, 'Address is null.');
+        $this->assertInstanceOf(Address::class, $address);
+    }
+
+    /**
+     * Address persisting test.
+     *
+     * @return void
+     */
+    public function test_address_create(): void
+    {
+        $addressLine1 = '300 N State St';
+        $locality = 'Chicago';
+        $postalCode = '60654';
+
+        $address = factory(Address::class)->create([
+            'address_line_1' => $addressLine1,
+            'locality' => $locality,
+            'postal_code' => $postalCode,
+        ]);
+
+        $this->assertDatabaseHas('nikolag_addresses', [
+            'address_line_1' => $addressLine1,
+            'locality' => $locality,
+            'postal_code' => $postalCode,
+        ]);
+    }
+
+    /**
+     * Test deleting Address cascades properly.
+     *
+     * @return void
+     */
+    public function test_delete_address(): void
+    {
+        $this->data->customer->address()->save($this->data->address);
+
+        $addressId = $this->data->address->id;
+        $this->data->address->delete();
+
+        $this->assertDatabaseMissing('nikolag_addresses', [
+            'id' => $addressId,
+        ]);
+
+        $this->data->customer->refresh();
+        $this->assertNull($this->data->customer->address);
+    }
+
+    /**
+     * Test Address factory creates valid US addresses.
+     *
+     * @return void
+     */
+    public function test_address_factory_creates_us_addresses(): void
+    {
+        $this->assertEquals('US', $this->data->address->country);
+        $this->assertNotNull($this->data->address->address_line_1);
+        $this->assertNotNull($this->data->address->locality);
+        $this->assertNotNull($this->data->address->administrative_district_level_1);
+        $this->assertNotNull($this->data->address->postal_code);
+    }
+
+    /**
+     * Test converting Address to Square Address object.
+     *
+     * @return void
+     */
+    public function test_address_to_square_address(): void
+    {
+        $address = factory(Address::class)->create([
+            'address_line_1' => '300 N State St',
+            'address_line_2' => 'Unit 4629',
+            'locality' => 'Chicago',
+            'administrative_district_level_1' => 'IL',
+            'postal_code' => '60654',
+            'country' => 'US',
+        ]);
+
+        $squareAddress = $address->toSquareAddress();
+
+        $this->assertInstanceOf(SquareAddress::class, $squareAddress);
+        $this->assertEquals('300 N State St', $squareAddress->getAddressLine1());
+        $this->assertEquals('Unit 4629', $squareAddress->getAddressLine2());
+        $this->assertEquals('Chicago', $squareAddress->getLocality());
+        $this->assertEquals('IL', $squareAddress->getAdministrativeDistrictLevel1());
+        $this->assertEquals('60654', $squareAddress->getPostalCode());
+        $this->assertEquals('US', $squareAddress->getCountry());
+    }
+
+    /**
+     * Test creating Address from Square Address object.
+     *
+     * @return void
+     */
+    public function test_address_from_square_address(): void
+    {
+        $squareAddress = new SquareAddress();
+        $squareAddress->setAddressLine1('300 N State St');
+        $squareAddress->setAddressLine2('Unit 4629');
+        $squareAddress->setLocality('Chicago');
+        $squareAddress->setAdministrativeDistrictLevel1('IL');
+        $squareAddress->setPostalCode('60654');
+        $squareAddress->setCountry('US');
+
+        $address = Address::fromSquareAddress($squareAddress);
+
+        $this->assertInstanceOf(Address::class, $address);
+        $this->assertEquals('300 N State St', $address->address_line_1);
+        $this->assertEquals('Unit 4629', $address->address_line_2);
+        $this->assertEquals('Chicago', $address->locality);
+        $this->assertEquals('IL', $address->administrative_district_level_1);
+        $this->assertEquals('60654', $address->postal_code);
+        $this->assertEquals('US', $address->country);
+    }
+
+    /**
+     * Test updating Address from Square Address object.
+     *
+     * @return void
+     */
+    public function test_address_update_from_square_address(): void
+    {
+        $address = factory(Address::class)->create([
+            'address_line_1' => 'Old Address',
+            'locality' => 'Old City',
+        ]);
+
+        $squareAddress = new SquareAddress();
+        $squareAddress->setAddressLine1('300 N State St');
+        $squareAddress->setAddressLine2('Unit 4629');
+        $squareAddress->setLocality('Chicago');
+        $squareAddress->setAdministrativeDistrictLevel1('IL');
+        $squareAddress->setPostalCode('60654');
+        $squareAddress->setCountry('US');
+
+        $address->updateFromSquareAddress($squareAddress);
+
+        $this->assertEquals('300 N State St', $address->address_line_1);
+        $this->assertEquals('Unit 4629', $address->address_line_2);
+        $this->assertEquals('Chicago', $address->locality);
+        $this->assertEquals('IL', $address->administrative_district_level_1);
+        $this->assertEquals('60654', $address->postal_code);
+        $this->assertEquals('US', $address->country);
+    }
+
+    /**
+     * Test Address belongs to Customer via polymorphic relationship.
+     *
+     * @return void
+     */
+    public function test_address_belongs_to_customer(): void
+    {
+        $this->data->customer->address()->save($this->data->address);
+        $this->data->address->refresh();
+
+        $this->assertNotNull($this->data->address->addressable_id);
+        $this->assertNotNull($this->data->address->addressable_type);
+        $this->assertEquals($this->data->customer->id, $this->data->address->addressable_id);
+        $this->assertEquals(Customer::class, $this->data->address->addressable_type);
+        $this->assertInstanceOf(Customer::class, $this->data->address->addressable);
+        $this->assertEquals($this->data->customer->id, $this->data->address->addressable->id);
+    }
+
+    /**
+     * Test Customer has one Address.
+     *
+     * @return void
+     */
+    public function test_customer_has_one_address(): void
+    {
+        $this->data->customer->address()->save($this->data->address);
+
+        $this->assertInstanceOf(Address::class, $this->data->customer->address);
+        $this->assertEquals($this->data->address->id, $this->data->customer->address->id);
+        $this->assertEquals($this->data->address->address_line_1, $this->data->customer->address->address_line_1);
+        $this->assertEquals($this->data->address->locality, $this->data->customer->address->locality);
+    }
+
+    /**
+     * Test creating Customer with Address in one operation.
+     *
+     * @return void
+     */
+    public function test_customer_create_with_address(): void
+    {
+        $address = factory(Address::class)->make([
+            'address_line_1' => '300 N State St',
+            'locality' => 'Chicago',
+            'postal_code' => '60654',
+        ]);
+
+        $this->data->customer->address()->save($address);
+
+        $this->assertDatabaseHas('nikolag_addresses', [
+            'addressable_type' => Customer::class,
+            'addressable_id' => $this->data->customer->id,
+            'address_line_1' => '300 N State St',
+            'locality' => 'Chicago',
+        ]);
+    }
+}


### PR DESCRIPTION
This PR introduces a new **Address** Model

## New Model
Due to the nature of [Addresses in Square](https://developer.squareup.com/docs/build-basics/common-data-types/working-with-addresses), a polymorphic relationship is best suited so we can establish a relationship between Customers and Addresses while also anticipating Addresses being attached to things like [DeliveryRecipient](https://developer.squareup.com/docs/build-basics/common-data-types/working-with-addresses) or [InvoiceRecipient](https://developer.squareup.com/docs/build-basics/common-data-types/working-with-addresses).

## New Trait
This adds a new `HasAddress` trait for use with these models, and adds supporting functions like `toSquareAddress` and `fromSquareAddress` to easily transpose data to and from Square's API classes.

## New Tests
There is a new test file `AddressTest` that covers the address model as well as the trait methods.