### PR TITLE
Adds additional customer fields, adds update square methods to service class

### DIFF
--- a/src/builders/SquareRequestBuilder.php
+++ b/src/builders/SquareRequestBuilder.php
@@ -88,11 +88,16 @@ class SquareRequestBuilder
         $request->setNickname($customer->nickname);
         $request->setEmailAddress($customer->email);
         $request->setPhoneNumber($customer->phone);
-        $request->setReferenceId($customer->owner_id);
+        $request->setReferenceId($customer->reference_id ?? $customer->owner_id);
         $request->setNote($customer->note);
 
+        // Add birthday if present
+        if ($customer->birthday) {
+            $request->setBirthday($customer->birthday->format('Y-m-d'));
+        }
+
         // Add address if customer has an address relationship
-        if ($customer->hasAddress()) {
+        if ($customer->address) {
             $request->setAddress($customer->address->toSquareAddress());
         }
 

--- a/src/builders/SquareRequestBuilder.php
+++ b/src/builders/SquareRequestBuilder.php
@@ -91,6 +91,11 @@ class SquareRequestBuilder
         $request->setReferenceId($customer->owner_id);
         $request->setNote($customer->note);
 
+        // Add address if customer has an address relationship
+        if ($customer->hasAddress()) {
+            $request->setAddress($customer->address->toSquareAddress());
+        }
+
         return $request;
     }
 

--- a/src/database/factories/ModelFactory.php
+++ b/src/database/factories/ModelFactory.php
@@ -3,6 +3,7 @@
 use Illuminate\Database\Eloquent\Factory as EloquentFactory;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Str;
+use Nikolag\Square\Models\Address;
 use Nikolag\Square\Tests\Models\Order;
 use Nikolag\Square\Tests\Models\User;
 use Nikolag\Square\Utils\Constants;
@@ -88,6 +89,24 @@ $factory->define(Constants::CUSTOMER_NAMESPACE, function (Faker\Generator $faker
         'email' => $faker->unique()->companyEmail,
         'phone' => $faker->unique()->tollFreePhoneNumber,
         'note' => $faker->unique()->paragraph(5),
+    ];
+});
+
+/* @var \Illuminate\Database\Eloquent\Factory $factory */
+$factory->define(Address::class, function (Faker\Generator $faker) {
+    return [
+        'address_line_1' => $faker->streetAddress,
+        'address_line_2' => $faker->optional(0.3)->secondaryAddress,
+        'address_line_3' => $faker->optional(0.1)->buildingNumber,
+        'locality' => $faker->city,
+        'administrative_district_level_1' => $faker->stateAbbr,
+        'administrative_district_level_2' => $faker->optional(0.2)->word,
+        'administrative_district_level_3' => $faker->optional(0.1)->word,
+        'sublocality' => $faker->optional(0.2)->streetName,
+        'sublocality_2' => $faker->optional(0.1)->word,
+        'sublocality_3' => $faker->optional(0.1)->word,
+        'postal_code' => $faker->postcode,
+        'country' => 'US',
     ];
 });
 

--- a/src/database/migrations/2025_12_23_145950_create_nikolag_addresses_table.php
+++ b/src/database/migrations/2025_12_23_145950_create_nikolag_addresses_table.php
@@ -1,0 +1,56 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * Create nikolag_addresses table for polymorphic address storage.
+ */
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('nikolag_addresses', function (Blueprint $table) {
+            $table->id();
+
+            // Polymorphic relationship fields (nullable for flexibility)
+            $table->nullableMorphs('addressable');
+
+            // Address fields following Square's Address object structure
+            $table->string('address_line_1', 500)->nullable();
+            $table->string('address_line_2', 500)->nullable();
+            $table->string('address_line_3', 500)->nullable();
+            $table->string('locality', 255)->nullable()->comment('City');
+            $table->string('administrative_district_level_1', 255)->nullable()->comment('State/Province');
+            $table->string('administrative_district_level_2', 255)->nullable()->comment('County/District');
+            $table->string('administrative_district_level_3', 255)->nullable()->comment('Sub-district');
+            $table->string('sublocality', 255)->nullable()->comment('Neighborhood');
+            $table->string('sublocality_2', 255)->nullable();
+            $table->string('sublocality_3', 255)->nullable();
+            $table->string('postal_code', 20)->nullable()->comment('ZIP/Postal code');
+            $table->string('country', 2)->nullable()->comment('ISO 3166-1-alpha-2 country code');
+
+            $table->timestamps();
+
+            // Indexes for common queries
+            $table->index('country');
+            $table->index('postal_code');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::dropIfExists('nikolag_addresses');
+    }
+};

--- a/src/database/migrations/2025_12_23_145955_add_square_customer_fields_to_nikolag_customers_table.php
+++ b/src/database/migrations/2025_12_23_145955_add_square_customer_fields_to_nikolag_customers_table.php
@@ -1,0 +1,89 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+use Square\Models\CustomerCreationSource;
+
+/**
+ * Add Square Customer API fields to nikolag_customers table.
+ *
+ * This migration adds comprehensive Square Customer fields including:
+ * - Birthday and reference_id for enhanced customer profiles
+ * - Version tracking for optimistic locking during updates
+ * - Separate address columns for better queryability
+ * - JSON fields for complex objects (preferences, groups, segments, tax IDs)
+ *
+ * Enables full parity with Square's Customer object and better sync consistency.
+ */
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('nikolag_customers', function (Blueprint $table) {
+            // Profile fields
+            $table->date('birthday')->nullable();
+            $table->string('reference_id')->nullable();
+            $table->enum('creation_source', [
+                CustomerCreationSource::OTHER,
+                CustomerCreationSource::APPOINTMENTS,
+                CustomerCreationSource::COUPON,
+                CustomerCreationSource::DELETION_RECOVERY,
+                CustomerCreationSource::DIRECTORY,
+                CustomerCreationSource::EGIFTING,
+                CustomerCreationSource::EMAIL_COLLECTION,
+                CustomerCreationSource::FEEDBACK,
+                CustomerCreationSource::IMPORT,
+                CustomerCreationSource::INVOICES,
+                CustomerCreationSource::LOYALTY,
+                CustomerCreationSource::MARKETING,
+                CustomerCreationSource::MERGE,
+                CustomerCreationSource::ONLINE_STORE,
+                CustomerCreationSource::INSTANT_PROFILE,
+                CustomerCreationSource::TERMINAL,
+                CustomerCreationSource::THIRD_PARTY,
+                CustomerCreationSource::THIRD_PARTY_IMPORT,
+                CustomerCreationSource::UNMERGE_RECOVERY,
+            ])->nullable();
+
+            // Version control for optimistic locking
+            $table->integer('payment_service_version')->nullable()->after('payment_service_id');
+
+            // Complex objects stored as JSON
+            $table->json('preferences')->nullable();
+            $table->json('group_ids')->nullable();
+            $table->json('segment_ids')->nullable();
+            $table->json('tax_ids')->nullable();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('nikolag_customers', function (Blueprint $table) {
+            // Drop all added columns
+            $table->dropColumn([
+                // Profile fields
+                'birthday',
+                'reference_id',
+                'creation_source',
+                'payment_service_version',
+
+                // Complex objects
+                'preferences',
+                'group_ids',
+                'segment_ids',
+                'tax_ids',
+            ]);
+        });
+    }
+};

--- a/src/models/Address.php
+++ b/src/models/Address.php
@@ -5,6 +5,7 @@ namespace Nikolag\Square\Models;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\MorphTo;
 use Square\Models\Address as SquareAddress;
+use Square\Models\Builders\AddressBuilder;
 
 class Address extends Model
 {
@@ -59,31 +60,30 @@ class Address extends Model
     /**
      * Convert address fields to Square Address object.
      *
-     * @return \Square\Models\Address
+     * @return SquareAddress
      */
     public function toSquareAddress(): SquareAddress
     {
-        $address = new SquareAddress();
-        $address->setAddressLine1($this->address_line_1);
-        $address->setAddressLine2($this->address_line_2);
-        $address->setAddressLine3($this->address_line_3);
-        $address->setLocality($this->locality);
-        $address->setAdministrativeDistrictLevel1($this->administrative_district_level_1);
-        $address->setAdministrativeDistrictLevel2($this->administrative_district_level_2);
-        $address->setAdministrativeDistrictLevel3($this->administrative_district_level_3);
-        $address->setSublocality($this->sublocality);
-        $address->setSublocality2($this->sublocality_2);
-        $address->setSublocality3($this->sublocality_3);
-        $address->setPostalCode($this->postal_code);
-        $address->setCountry($this->country);
-
-        return $address;
+        return AddressBuilder::init()
+        ->addressLine1($this->address_line_1)
+        ->addressLine2($this->address_line_2)
+        ->addressLine3($this->address_line_3)
+        ->locality($this->locality)
+        ->administrativeDistrictLevel1($this->administrative_district_level_1)
+        ->administrativeDistrictLevel2($this->administrative_district_level_2)
+        ->administrativeDistrictLevel3($this->administrative_district_level_3)
+        ->sublocality($this->sublocality)
+        ->sublocality2($this->sublocality_2)
+        ->sublocality3($this->sublocality_3)
+        ->postalCode($this->postal_code)
+        ->country($this->country)
+        ->build();
     }
 
     /**
      * Create an Address model from Square Address object.
      *
-     * @param  \Square\Models\Address  $squareAddress
+     * @param  SquareAddress  $squareAddress
      * @return static
      */
     public static function fromSquareAddress(SquareAddress $squareAddress): static

--- a/src/models/Address.php
+++ b/src/models/Address.php
@@ -1,0 +1,130 @@
+<?php
+
+namespace Nikolag\Square\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\MorphTo;
+use Square\Models\Address as SquareAddress;
+
+class Address extends Model
+{
+    /**
+     * The table associated with the model.
+     *
+     * @var string
+     */
+    protected $table = 'nikolag_addresses';
+
+    /**
+     * The attributes that are mass assignable.
+     *
+     * @var array
+     */
+    protected $fillable = [
+        'address_line_1',
+        'address_line_2',
+        'address_line_3',
+        'locality',
+        'administrative_district_level_1',
+        'administrative_district_level_2',
+        'administrative_district_level_3',
+        'sublocality',
+        'sublocality_2',
+        'sublocality_3',
+        'postal_code',
+        'country',
+    ];
+
+    /**
+     * The attributes that aren't mass assignable.
+     *
+     * @var array
+     */
+    protected $guarded = [
+        'id',
+        'addressable_type',
+        'addressable_id',
+    ];
+
+    /**
+     * Get the parent addressable model (Customer, Recipient, etc.).
+     *
+     * @return \Illuminate\Database\Eloquent\Relations\MorphTo
+     */
+    public function addressable(): MorphTo
+    {
+        return $this->morphTo();
+    }
+
+    /**
+     * Convert address fields to Square Address object.
+     *
+     * @return \Square\Models\Address
+     */
+    public function toSquareAddress(): SquareAddress
+    {
+        $address = new SquareAddress();
+        $address->setAddressLine1($this->address_line_1);
+        $address->setAddressLine2($this->address_line_2);
+        $address->setAddressLine3($this->address_line_3);
+        $address->setLocality($this->locality);
+        $address->setAdministrativeDistrictLevel1($this->administrative_district_level_1);
+        $address->setAdministrativeDistrictLevel2($this->administrative_district_level_2);
+        $address->setAdministrativeDistrictLevel3($this->administrative_district_level_3);
+        $address->setSublocality($this->sublocality);
+        $address->setSublocality2($this->sublocality_2);
+        $address->setSublocality3($this->sublocality_3);
+        $address->setPostalCode($this->postal_code);
+        $address->setCountry($this->country);
+
+        return $address;
+    }
+
+    /**
+     * Create an Address model from Square Address object.
+     *
+     * @param  \Square\Models\Address  $squareAddress
+     * @return static
+     */
+    public static function fromSquareAddress(SquareAddress $squareAddress): static
+    {
+        return new static([
+            'address_line_1' => $squareAddress->getAddressLine1(),
+            'address_line_2' => $squareAddress->getAddressLine2(),
+            'address_line_3' => $squareAddress->getAddressLine3(),
+            'locality' => $squareAddress->getLocality(),
+            'administrative_district_level_1' => $squareAddress->getAdministrativeDistrictLevel1(),
+            'administrative_district_level_2' => $squareAddress->getAdministrativeDistrictLevel2(),
+            'administrative_district_level_3' => $squareAddress->getAdministrativeDistrictLevel3(),
+            'sublocality' => $squareAddress->getSublocality(),
+            'sublocality_2' => $squareAddress->getSublocality2(),
+            'sublocality_3' => $squareAddress->getSublocality3(),
+            'postal_code' => $squareAddress->getPostalCode(),
+            'country' => $squareAddress->getCountry(),
+        ]);
+    }
+
+    /**
+     * Update address fields from Square Address object.
+     *
+     * @param  \Square\Models\Address  $squareAddress
+     * @return void
+     */
+    public function updateFromSquareAddress(SquareAddress $squareAddress): void
+    {
+        $this->fill([
+            'address_line_1' => $squareAddress->getAddressLine1(),
+            'address_line_2' => $squareAddress->getAddressLine2(),
+            'address_line_3' => $squareAddress->getAddressLine3(),
+            'locality' => $squareAddress->getLocality(),
+            'administrative_district_level_1' => $squareAddress->getAdministrativeDistrictLevel1(),
+            'administrative_district_level_2' => $squareAddress->getAdministrativeDistrictLevel2(),
+            'administrative_district_level_3' => $squareAddress->getAdministrativeDistrictLevel3(),
+            'sublocality' => $squareAddress->getSublocality(),
+            'sublocality_2' => $squareAddress->getSublocality2(),
+            'sublocality_3' => $squareAddress->getSublocality3(),
+            'postal_code' => $squareAddress->getPostalCode(),
+            'country' => $squareAddress->getCountry(),
+        ]);
+    }
+}

--- a/src/models/Customer.php
+++ b/src/models/Customer.php
@@ -21,6 +21,54 @@ class Customer extends CoreCustomer
     ];
 
     /**
+     * The attributes that are mass assignable.
+     *
+     * @var array
+     */
+    protected $fillable = [
+        'first_name',
+        'last_name',
+        'company_name',
+        'nickname',
+        'email',
+        'phone',
+        'note',
+        'birthday',
+        'reference_id',
+        'creation_source',
+        'preferences',
+        'group_ids',
+        'segment_ids',
+        'tax_ids',
+    ];
+
+    /**
+     * The attributes that should be cast to native types.
+     *
+     * @var array
+     */
+    protected $casts = [
+        'created_at' => 'datetime',
+        'updated_at' => 'datetime',
+        'birthday' => 'date',
+        'preferences' => 'array',
+        'group_ids' => 'array',
+        'segment_ids' => 'array',
+        'tax_ids' => 'array',
+    ];
+
+    /**
+     * The attributes that aren't mass assignable.
+     *
+     * @var array
+     */
+    protected $guarded = [
+        'id',
+        'payment_service_id',
+        'payment_service_version',
+    ];
+
+    /**
      * List of users this customer bought from.
      *
      * @return \Illuminate\Database\Eloquent\Relations\BelongsToMany

--- a/src/models/Customer.php
+++ b/src/models/Customer.php
@@ -4,10 +4,13 @@ namespace Nikolag\Square\Models;
 
 use DateTimeInterface;
 use Nikolag\Core\Models\Customer as CoreCustomer;
+use Nikolag\Square\Traits\HasAddress;
 use Nikolag\Square\Utils\Constants;
 
 class Customer extends CoreCustomer
 {
+    use HasAddress;
+
     /**
      * The model's attributes.
      *

--- a/src/traits/HasAddress.php
+++ b/src/traits/HasAddress.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace Nikolag\Square\Traits;
+
+use Illuminate\Database\Eloquent\Relations\MorphOne;
+use Nikolag\Square\Models\Address;
+use Square\Models\Address as SquareAddress;
+
+trait HasAddress
+{
+    /**
+     * Get the address relationship.
+     *
+     * @return MorphOne
+     */
+    public function address(): MorphOne
+    {
+        return $this->morphOne(Address::class, 'addressable');
+    }
+
+    /**
+     * Check if the model has an address.
+     *
+     * @return bool
+     */
+    public function hasAddress(): bool
+    {
+        return $this->address()->exists();
+    }
+
+    /**
+     * Get the address as a Square Address object.
+     *
+     * @return SquareAddress|null
+     */
+    public function getSquareAddress(): ?SquareAddress
+    {
+        if (! $this->address) {
+            return null;
+        }
+
+        return $this->address->toSquareAddress();
+    }
+
+    /**
+     * Create or update address from Square Address object.
+     *
+     * @param  SquareAddress  $squareAddress
+     * @return Address
+     */
+    public function syncAddressFromSquare(SquareAddress $squareAddress): Address
+    {
+        $address = $this->address()->firstOrNew([]);
+        $address->updateFromSquareAddress($squareAddress);
+        $this->address()->save($address);
+
+        return $address;
+    }
+}

--- a/tests/TestDataHolder.php
+++ b/tests/TestDataHolder.php
@@ -2,6 +2,7 @@
 
 namespace Nikolag\Square\Tests;
 
+use Nikolag\Square\Models\Address;
 use Nikolag\Square\Models\Customer;
 use Nikolag\Square\Models\Discount;
 use Nikolag\Square\Models\Product;
@@ -16,7 +17,8 @@ class TestDataHolder
                                 public ?Customer $customer,
                                 public ?User $merchant,
                                 public ?Tax $tax,
-                                public ?Discount $discount)
+                                public ?Discount $discount,
+                                public ?Address $address)
     {
     }
 
@@ -27,7 +29,8 @@ class TestDataHolder
             factory(Customer::class)->make(),
             factory(User::class)->make(),
             factory(Tax::class)->make(),
-            factory(Discount::class)->states('AMOUNT_ONLY')->make());
+            factory(Discount::class)->states('AMOUNT_ONLY')->make(),
+            factory(Address::class)->make());
     }
 
     public static function create(): self
@@ -37,7 +40,8 @@ class TestDataHolder
             factory(Customer::class)->create(),
             factory(User::class)->create(),
             factory(Tax::class)->create(),
-            factory(Discount::class)->states('AMOUNT_ONLY')->create());
+            factory(Discount::class)->states('AMOUNT_ONLY')->create(),
+            factory(Address::class)->create());
     }
 
     public function modify(string $prodFac = 'create',
@@ -45,7 +49,8 @@ class TestDataHolder
                            string $orderDisFac = 'create',
                            string $orderDiscFixFac = 'create',
                            string $taxAddFac = 'create',
-                           string $taxIncFac = 'create')
+                           string $taxIncFac = 'create',
+                           string $addressFac = 'create')
     {
         $product = factory(Product::class)->{$prodFac}([
             'price' => 1000,
@@ -65,7 +70,8 @@ class TestDataHolder
         $taxInclusive = factory(Tax::class)->states('INCLUSIVE')->{$taxIncFac}([
             'percentage' => 15.0,
         ]);
+        $address = factory(Address::class)->{$addressFac}();
 
-        return compact('product', 'productDiscount', 'orderDiscount', 'orderDiscountFixed', 'taxAdditive', 'taxInclusive');
+        return compact('product', 'productDiscount', 'orderDiscount', 'orderDiscountFixed', 'taxAdditive', 'taxInclusive', 'address');
     }
 }

--- a/tests/unit/AddressTest.php
+++ b/tests/unit/AddressTest.php
@@ -1,0 +1,235 @@
+<?php
+
+namespace Nikolag\Square\Tests\Unit;
+
+use Nikolag\Square\Models\Address;
+use Nikolag\Square\Models\Customer;
+use Nikolag\Square\Models\Recipient;
+use Nikolag\Square\Tests\TestCase;
+use Nikolag\Square\Tests\TestDataHolder;
+use Square\Models\Address as SquareAddress;
+
+class AddressTest extends TestCase
+{
+    private TestDataHolder $data;
+    private Recipient $recipient;
+
+    /**
+     * @return void
+     */
+    public function setUp(): void
+    {
+        parent::setUp();
+        $this->data = TestDataHolder::create();
+    }
+
+    /**
+     * Address creation test.
+     *
+     * @return void
+     */
+    public function test_address_make(): void
+    {
+        $address = factory(Address::class)->create();
+
+        $this->assertNotNull($address, 'Address is null.');
+        $this->assertInstanceOf(Address::class, $address);
+    }
+
+    /**
+     * Address persisting test.
+     *
+     * @return void
+     */
+    public function test_address_create(): void
+    {
+        $addressLine1 = '300 N State St';
+        $locality = 'Chicago';
+        $postalCode = '60654';
+
+        $address = factory(Address::class)->create([
+            'address_line_1' => $addressLine1,
+            'locality' => $locality,
+            'postal_code' => $postalCode,
+        ]);
+
+        $this->assertDatabaseHas('nikolag_addresses', [
+            'address_line_1' => $addressLine1,
+            'locality' => $locality,
+            'postal_code' => $postalCode,
+        ]);
+    }
+
+    /**
+     * Test deleting Address cascades properly.
+     *
+     * @return void
+     */
+    public function test_delete_address(): void
+    {
+        $this->data->customer->address()->save($this->data->address);
+
+        $addressId = $this->data->address->id;
+        $this->data->address->delete();
+
+        $this->assertDatabaseMissing('nikolag_addresses', [
+            'id' => $addressId,
+        ]);
+
+        $this->data->customer->refresh();
+        $this->assertNull($this->data->customer->address);
+    }
+
+    /**
+     * Test Address factory creates valid US addresses.
+     *
+     * @return void
+     */
+    public function test_address_factory_creates_us_addresses(): void
+    {
+        $this->assertEquals('US', $this->data->address->country);
+        $this->assertNotNull($this->data->address->address_line_1);
+        $this->assertNotNull($this->data->address->locality);
+        $this->assertNotNull($this->data->address->administrative_district_level_1);
+        $this->assertNotNull($this->data->address->postal_code);
+    }
+
+    /**
+     * Test converting Address to Square Address object.
+     *
+     * @return void
+     */
+    public function test_address_to_square_address(): void
+    {
+        $address = factory(Address::class)->create([
+            'address_line_1' => '300 N State St',
+            'address_line_2' => 'Unit 4629',
+            'locality' => 'Chicago',
+            'administrative_district_level_1' => 'IL',
+            'postal_code' => '60654',
+            'country' => 'US',
+        ]);
+
+        $squareAddress = $address->toSquareAddress();
+
+        $this->assertInstanceOf(SquareAddress::class, $squareAddress);
+        $this->assertEquals('300 N State St', $squareAddress->getAddressLine1());
+        $this->assertEquals('Unit 4629', $squareAddress->getAddressLine2());
+        $this->assertEquals('Chicago', $squareAddress->getLocality());
+        $this->assertEquals('IL', $squareAddress->getAdministrativeDistrictLevel1());
+        $this->assertEquals('60654', $squareAddress->getPostalCode());
+        $this->assertEquals('US', $squareAddress->getCountry());
+    }
+
+    /**
+     * Test creating Address from Square Address object.
+     *
+     * @return void
+     */
+    public function test_address_from_square_address(): void
+    {
+        $squareAddress = new SquareAddress();
+        $squareAddress->setAddressLine1('300 N State St');
+        $squareAddress->setAddressLine2('Unit 4629');
+        $squareAddress->setLocality('Chicago');
+        $squareAddress->setAdministrativeDistrictLevel1('IL');
+        $squareAddress->setPostalCode('60654');
+        $squareAddress->setCountry('US');
+
+        $address = Address::fromSquareAddress($squareAddress);
+
+        $this->assertInstanceOf(Address::class, $address);
+        $this->assertEquals('300 N State St', $address->address_line_1);
+        $this->assertEquals('Unit 4629', $address->address_line_2);
+        $this->assertEquals('Chicago', $address->locality);
+        $this->assertEquals('IL', $address->administrative_district_level_1);
+        $this->assertEquals('60654', $address->postal_code);
+        $this->assertEquals('US', $address->country);
+    }
+
+    /**
+     * Test updating Address from Square Address object.
+     *
+     * @return void
+     */
+    public function test_address_update_from_square_address(): void
+    {
+        $address = factory(Address::class)->create([
+            'address_line_1' => 'Old Address',
+            'locality' => 'Old City',
+        ]);
+
+        $squareAddress = new SquareAddress();
+        $squareAddress->setAddressLine1('300 N State St');
+        $squareAddress->setAddressLine2('Unit 4629');
+        $squareAddress->setLocality('Chicago');
+        $squareAddress->setAdministrativeDistrictLevel1('IL');
+        $squareAddress->setPostalCode('60654');
+        $squareAddress->setCountry('US');
+
+        $address->updateFromSquareAddress($squareAddress);
+
+        $this->assertEquals('300 N State St', $address->address_line_1);
+        $this->assertEquals('Unit 4629', $address->address_line_2);
+        $this->assertEquals('Chicago', $address->locality);
+        $this->assertEquals('IL', $address->administrative_district_level_1);
+        $this->assertEquals('60654', $address->postal_code);
+        $this->assertEquals('US', $address->country);
+    }
+
+    /**
+     * Test Address belongs to Customer via polymorphic relationship.
+     *
+     * @return void
+     */
+    public function test_address_belongs_to_customer(): void
+    {
+        $this->data->customer->address()->save($this->data->address);
+        $this->data->address->refresh();
+
+        $this->assertNotNull($this->data->address->addressable_id);
+        $this->assertNotNull($this->data->address->addressable_type);
+        $this->assertEquals($this->data->customer->id, $this->data->address->addressable_id);
+        $this->assertEquals(Customer::class, $this->data->address->addressable_type);
+        $this->assertInstanceOf(Customer::class, $this->data->address->addressable);
+        $this->assertEquals($this->data->customer->id, $this->data->address->addressable->id);
+    }
+
+    /**
+     * Test Customer has one Address.
+     *
+     * @return void
+     */
+    public function test_customer_has_one_address(): void
+    {
+        $this->data->customer->address()->save($this->data->address);
+
+        $this->assertInstanceOf(Address::class, $this->data->customer->address);
+        $this->assertEquals($this->data->address->id, $this->data->customer->address->id);
+        $this->assertEquals($this->data->address->address_line_1, $this->data->customer->address->address_line_1);
+        $this->assertEquals($this->data->address->locality, $this->data->customer->address->locality);
+    }
+
+    /**
+     * Test creating Customer with Address in one operation.
+     *
+     * @return void
+     */
+    public function test_customer_create_with_address(): void
+    {
+        $address = factory(Address::class)->make([
+            'address_line_1' => '300 N State St',
+            'locality' => 'Chicago',
+            'postal_code' => '60654',
+        ]);
+
+        $this->data->customer->address()->save($address);
+
+        $this->assertDatabaseHas('nikolag_addresses', [
+            'addressable_type' => Customer::class,
+            'addressable_id' => $this->data->customer->id,
+            'address_line_1' => '300 N State St',
+            'locality' => 'Chicago',
+        ]);
+    }
+}

--- a/tests/unit/SquareServiceCustomerTest.php
+++ b/tests/unit/SquareServiceCustomerTest.php
@@ -1,0 +1,560 @@
+<?php
+
+namespace Nikolag\Square\Tests\Unit;
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Nikolag\Square\Exception;
+use Nikolag\Square\Facades\Square;
+use Nikolag\Square\Models\Address;
+use Nikolag\Square\Models\Customer;
+use Nikolag\Square\Tests\Models\User;
+use Nikolag\Square\Tests\TestCase;
+use Nikolag\Square\Tests\Traits\MocksSquareConfigDependency;
+use Square\Models\Address as SquareAddress;
+use Square\Models\Builders\AddressBuilder;
+use Square\Models\Builders\CustomerPreferencesBuilder;
+use Square\Models\CustomerCreationSource;
+
+class SquareServiceCustomerTest extends TestCase
+{
+    use RefreshDatabase, MocksSquareConfigDependency;
+
+    private User $merchant;
+
+    /**
+     * @return void
+     */
+    public function setUp(): void
+    {
+        parent::setUp();
+        $this->merchant = factory(User::class)->create();
+    }
+
+    /**
+     * Test creating a new customer successfully stores payment_service_id and version.
+     */
+    public function test_create_customer_stores_payment_service_id_and_version(): void
+    {
+        $customer = factory(Customer::class)->create([
+            'first_name' => 'John',
+            'last_name' => 'Doe',
+            'email' => 'john.doe@example.com',
+        ]);
+
+        // Mock the create customer API call
+        $this->mockCreateCustomerSuccess([
+            'id' => 'CUSTOMER_TEST_123',
+            'givenName' => 'John',
+            'familyName' => 'Doe',
+            'emailAddress' => 'john.doe@example.com',
+            'version' => 1,
+            'createdAt' => now()->toISOString(),
+            'updatedAt' => now()->toISOString(),
+        ]);
+
+        // Save customer via Square facade
+        Square::setMerchant($this->merchant)
+            ->setCustomer($customer)
+            ->save();
+
+        // Refresh customer to get updated values
+        $customer->refresh();
+
+        // Verify payment_service_id and version are stored
+        $this->assertNotNull($customer->payment_service_id);
+        $this->assertEquals('CUSTOMER_TEST_123', $customer->payment_service_id);
+        $this->assertEquals(1, $customer->payment_service_version);
+
+        // Verify customer is saved to database
+        $this->assertDatabaseHas('nikolag_customers', [
+            'payment_service_id' => 'CUSTOMER_TEST_123',
+            'payment_service_version' => 1,
+            'email' => 'john.doe@example.com',
+        ]);
+    }
+
+    /**
+     * Test creating a new customer with creation_source field.
+     */
+    public function test_create_customer_stores_creation_source(): void
+    {
+        $customer = factory(Customer::class)->create([
+            'first_name' => 'Jane',
+            'last_name' => 'Smith',
+            'email' => 'jane.smith@example.com',
+        ]);
+
+        // Mock the create customer API call with creation_source
+        $this->mockCreateCustomerSuccess([
+            'id' => 'CUSTOMER_TEST_456',
+            'givenName' => 'Jane',
+            'familyName' => 'Smith',
+            'emailAddress' => 'jane.smith@example.com',
+            'version' => 1,
+            'creationSource' => CustomerCreationSource::THIRD_PARTY,
+            'createdAt' => now()->toISOString(),
+            'updatedAt' => now()->toISOString(),
+        ]);
+
+        // Save customer
+        Square::setMerchant($this->merchant)
+            ->setCustomer($customer)
+            ->save();
+
+        // Refresh customer to get updated values
+        $customer->refresh();
+
+        // Verify creation_source is stored
+        $this->assertEquals(CustomerCreationSource::THIRD_PARTY, $customer->creation_source);
+
+        $this->assertDatabaseHas('nikolag_customers', [
+            'payment_service_id' => 'CUSTOMER_TEST_456',
+            'creation_source' => CustomerCreationSource::THIRD_PARTY,
+        ]);
+    }
+
+    /**
+     * Test creating a new customer with address syncs address from Square response.
+     */
+    public function test_create_customer_syncs_address_from_square_response(): void
+    {
+        $customer = factory(Customer::class)->create([
+            'first_name' => 'Bob',
+            'last_name' => 'Johnson',
+            'email' => 'bob.johnson@example.com',
+        ]);
+
+        // Build Square address
+        $squareAddress = AddressBuilder::init()
+            ->addressLine1('123 Main St')
+            ->addressLine2('Apt 4')
+            ->locality('Chicago')
+            ->administrativeDistrictLevel1('IL')
+            ->postalCode('60601')
+            ->country('US')
+            ->build();
+
+        // Mock the create customer API call with address
+        $this->mockCreateCustomerSuccess([
+            'id' => 'CUSTOMER_TEST_789',
+            'givenName' => 'Bob',
+            'familyName' => 'Johnson',
+            'emailAddress' => 'bob.johnson@example.com',
+            'version' => 1,
+            'address' => $squareAddress,
+            'createdAt' => now()->toISOString(),
+            'updatedAt' => now()->toISOString(),
+        ]);
+
+        // Save customer
+        Square::setMerchant($this->merchant)
+            ->setCustomer($customer)
+            ->save();
+
+        // Refresh customer to load relationship
+        $customer->refresh();
+
+        // Verify address is created and associated
+        $this->assertNotNull($customer->address);
+        $this->assertEquals('123 Main St', $customer->address->address_line_1);
+        $this->assertEquals('Apt 4', $customer->address->address_line_2);
+        $this->assertEquals('Chicago', $customer->address->locality);
+        $this->assertEquals('IL', $customer->address->administrative_district_level_1);
+        $this->assertEquals('60601', $customer->address->postal_code);
+        $this->assertEquals('US', $customer->address->country);
+
+        // Verify address is in database
+        $this->assertDatabaseHas('nikolag_addresses', [
+            'addressable_type' => Customer::class,
+            'addressable_id' => $customer->id,
+            'address_line_1' => '123 Main St',
+            'locality' => 'Chicago',
+        ]);
+    }
+
+    /**
+     * Test creating a new customer with preferences syncs from Square response.
+     */
+    public function test_create_customer_syncs_preferences_from_square_response(): void
+    {
+        $customer = factory(Customer::class)->create([
+            'first_name' => 'Alice',
+            'last_name' => 'Williams',
+            'email' => 'alice.williams@example.com',
+        ]);
+
+        // Build preferences
+        $preferences = CustomerPreferencesBuilder::init()
+            ->emailUnsubscribed(true)
+            ->build();
+
+        // Mock the create customer API call with preferences
+        $this->mockCreateCustomerSuccess([
+            'id' => 'CUSTOMER_TEST_101',
+            'givenName' => 'Alice',
+            'familyName' => 'Williams',
+            'emailAddress' => 'alice.williams@example.com',
+            'version' => 1,
+            'preferences' => $preferences,
+            'createdAt' => now()->toISOString(),
+            'updatedAt' => now()->toISOString(),
+        ]);
+
+        // Save customer
+        Square::setMerchant($this->merchant)
+            ->setCustomer($customer)
+            ->save();
+
+        // Refresh customer to get updated values
+        $customer->refresh();
+
+        // Verify preferences are stored
+        $this->assertNotNull($customer->preferences);
+        $this->assertTrue($customer->preferences['email_unsubscribed']);
+
+        $this->assertDatabaseHas('nikolag_customers', [
+            'payment_service_id' => 'CUSTOMER_TEST_101',
+        ]);
+
+        // Verify JSON field
+        $freshCustomer = Customer::find($customer->id);
+        $this->assertTrue($freshCustomer->preferences['email_unsubscribed']);
+    }
+
+    /**
+     * Test creating a new customer with group_ids and segment_ids.
+     */
+    public function test_create_customer_syncs_group_and_segment_ids_from_square_response(): void
+    {
+        $customer = factory(Customer::class)->create([
+            'first_name' => 'Charlie',
+            'last_name' => 'Brown',
+            'email' => 'charlie.brown@example.com',
+        ]);
+
+        $groupIds = ['GROUP_1', 'GROUP_2'];
+        $segmentIds = ['SEGMENT_A', 'SEGMENT_B'];
+
+        // Mock the create customer API call with groups and segments
+        $this->mockCreateCustomerSuccess([
+            'id' => 'CUSTOMER_TEST_202',
+            'givenName' => 'Charlie',
+            'familyName' => 'Brown',
+            'emailAddress' => 'charlie.brown@example.com',
+            'version' => 1,
+            'groupIds' => $groupIds,
+            'segmentIds' => $segmentIds,
+            'createdAt' => now()->toISOString(),
+            'updatedAt' => now()->toISOString(),
+        ]);
+
+        // Save customer
+        Square::setMerchant($this->merchant)
+            ->setCustomer($customer)
+            ->save();
+
+        // Refresh customer to get updated values
+        $customer->refresh();
+
+        // Verify groups and segments are stored
+        $this->assertEquals($groupIds, $customer->group_ids);
+        $this->assertEquals($segmentIds, $customer->segment_ids);
+
+        // Verify in database
+        $freshCustomer = Customer::find($customer->id);
+        $this->assertEquals($groupIds, $freshCustomer->group_ids);
+        $this->assertEquals($segmentIds, $freshCustomer->segment_ids);
+    }
+
+    /**
+     * Test creating a customer fails with Square API error.
+     */
+    public function test_create_customer_handles_api_error(): void
+    {
+        $customer = factory(Customer::class)->create([
+            'first_name' => 'Error',
+            'last_name' => 'Test',
+            'email' => 'error@example.com',
+        ]);
+
+        // Mock API error
+        $this->mockCreateCustomerError('Customer creation failed due to invalid email', 400);
+
+        $this->expectException(Exception::class);
+
+        // Attempt to save customer
+        Square::setMerchant($this->merchant)
+            ->setCustomer($customer)
+            ->save();
+    }
+
+    /**
+     * Test updating an existing customer updates version number.
+     */
+    public function test_update_customer_syncs_version(): void
+    {
+        // Create customer with existing payment_service_id
+        $customer = factory(Customer::class)->create([
+            'first_name' => 'David',
+            'last_name' => 'Miller',
+            'email' => 'david.miller@example.com',
+        ]);
+
+        // Manually set guarded fields (bypassing mass assignment protection)
+        $customer->payment_service_id = 'EXISTING_CUSTOMER_123';
+        $customer->payment_service_version = 1;
+        $customer->save();
+
+        // Verify customer has payment_service_id
+        $customer->refresh();
+        $this->assertEquals('EXISTING_CUSTOMER_123', $customer->payment_service_id);
+        $this->assertEquals(1, $customer->payment_service_version);
+
+        // Mock the update customer API call
+        $this->mockUpdateCustomerSuccess([
+            'id' => 'EXISTING_CUSTOMER_123',
+            'givenName' => 'David',
+            'familyName' => 'Miller',
+            'emailAddress' => 'david.miller@example.com', // Keep original email
+            'version' => 2, // Version incremented
+            'createdAt' => now()->subDay()->toISOString(),
+            'updatedAt' => now()->toISOString(),
+        ]);
+
+        // Save customer (DO NOT change email before setCustomer - customerBuilder queries by email!)
+        Square::setMerchant($this->merchant)
+            ->setCustomer($customer)
+            ->save();
+
+        // Verify version was incremented
+        $customer->refresh();
+        $this->assertEquals(2, $customer->payment_service_version);
+
+        $this->assertDatabaseHas('nikolag_customers', [
+            'payment_service_id' => 'EXISTING_CUSTOMER_123',
+            'payment_service_version' => 2,
+            'email' => 'david.miller@example.com',
+        ]);
+    }
+
+    /**
+     * Test updating an existing customer syncs address from Square response.
+     */
+    public function test_update_customer_syncs_updated_address_from_square_response(): void
+    {
+        // Create customer with existing address
+        $customer = factory(Customer::class)->create([
+            'first_name' => 'Emma',
+            'last_name' => 'Davis',
+            'email' => 'emma.davis@example.com',
+        ]);
+
+        // Manually set guarded fields (bypassing mass assignment protection)
+        $customer->payment_service_id = 'EXISTING_CUSTOMER_456';
+        $customer->payment_service_version = 1;
+        $customer->save();
+
+        $oldAddress = factory(Address::class)->create([
+            'address_line_1' => 'Old Address St',
+            'locality' => 'Old City',
+        ]);
+        $customer->address()->save($oldAddress);
+
+        // Build updated Square address
+        $updatedSquareAddress = AddressBuilder::init()
+            ->addressLine1('456 New Ave')
+            ->addressLine2('Suite 100')
+            ->locality('New York')
+            ->administrativeDistrictLevel1('NY')
+            ->postalCode('10001')
+            ->country('US')
+            ->build();
+
+        // Mock the update customer API call with new address
+        // NOTE: Keep email same as original - CustomerBuilder queries by email!
+        $this->mockUpdateCustomerSuccess([
+            'id' => 'EXISTING_CUSTOMER_456',
+            'givenName' => 'Emma',
+            'familyName' => 'Davis',
+            'emailAddress' => 'emma.davis@example.com', // Keep original email
+            'version' => 2,
+            'address' => $updatedSquareAddress,
+            'createdAt' => now()->subDay()->toISOString(),
+            'updatedAt' => now()->toISOString(),
+        ]);
+
+        // Save customer (triggers update)
+        Square::setMerchant($this->merchant)
+            ->setCustomer($customer)
+            ->save();
+
+        // Refresh customer to load updated relationship
+        $customer->refresh();
+
+        // Verify address was updated
+        $this->assertEquals('456 New Ave', $customer->address->address_line_1);
+        $this->assertEquals('Suite 100', $customer->address->address_line_2);
+        $this->assertEquals('New York', $customer->address->locality);
+        $this->assertEquals('NY', $customer->address->administrative_district_level_1);
+        $this->assertEquals('10001', $customer->address->postal_code);
+        $this->assertEquals('US', $customer->address->country);
+    }
+
+    /**
+     * Test updating an existing customer syncs preferences, groups, and segments.
+     */
+    public function test_update_customer_syncs_preferences_groups_segments_from_square_response(): void
+    {
+        // Create customer
+        $customer = factory(Customer::class)->create([
+            'first_name' => 'Frank',
+            'last_name' => 'Wilson',
+            'email' => 'frank.wilson@example.com',
+        ]);
+
+        // Manually set guarded fields (bypassing mass assignment protection)
+        $customer->payment_service_id = 'EXISTING_CUSTOMER_789';
+        $customer->payment_service_version = 1;
+        $customer->save();
+
+        // Build updated data
+        $preferences = CustomerPreferencesBuilder::init()
+            ->emailUnsubscribed(false)
+            ->build();
+
+        $updatedGroupIds = ['GROUP_3', 'GROUP_4'];
+        $updatedSegmentIds = ['SEGMENT_C', 'SEGMENT_D'];
+
+        // Mock the update customer API call
+        $this->mockUpdateCustomerSuccess([
+            'id' => 'EXISTING_CUSTOMER_789',
+            'givenName' => 'Frank',
+            'familyName' => 'Wilson',
+            'emailAddress' => 'frank.wilson@example.com',
+            'version' => 2,
+            'preferences' => $preferences,
+            'groupIds' => $updatedGroupIds,
+            'segmentIds' => $updatedSegmentIds,
+            'createdAt' => now()->subDay()->toISOString(),
+            'updatedAt' => now()->toISOString(),
+        ]);
+
+        // Save customer
+        Square::setMerchant($this->merchant)
+            ->setCustomer($customer)
+            ->save();
+
+        // Refresh to get updated data from database
+        $customer->refresh();
+
+        // Verify updated data
+        $this->assertFalse($customer->preferences['email_unsubscribed']);
+        $this->assertEquals($updatedGroupIds, $customer->group_ids);
+        $this->assertEquals($updatedSegmentIds, $customer->segment_ids);
+
+        // Verify version incremented
+        $this->assertEquals(2, $customer->payment_service_version);
+    }
+
+    /**
+     * Test updating a customer fails with Square API error.
+     */
+    public function test_update_customer_handles_api_error(): void
+    {
+        $customer = factory(Customer::class)->create([
+            'first_name' => 'Error',
+            'last_name' => 'Update',
+            'email' => 'error.update@example.com',
+        ]);
+
+        // Manually set guarded fields (bypassing mass assignment protection)
+        $customer->payment_service_id = 'EXISTING_CUSTOMER_ERROR';
+        $customer->payment_service_version = 1;
+        $customer->save();
+
+        // Mock API error
+        $this->mockUpdateCustomerError('Customer update failed', 400);
+
+        $this->expectException(Exception::class);
+
+        // Attempt to update customer
+        Square::setMerchant($this->merchant)
+            ->setCustomer($customer)
+            ->save();
+    }
+
+    /**
+     * Test customer with birthday field is properly synced.
+     */
+    public function test_create_customer_with_birthday(): void
+    {
+        $customer = factory(Customer::class)->create([
+            'first_name' => 'Birthday',
+            'last_name' => 'Test',
+            'email' => 'birthday@example.com',
+            'birthday' => '1990-05-15',
+        ]);
+
+        // Mock the create customer API call with birthday
+        $this->mockCreateCustomerSuccess([
+            'id' => 'CUSTOMER_BIRTHDAY_123',
+            'givenName' => 'Birthday',
+            'familyName' => 'Test',
+            'emailAddress' => 'birthday@example.com',
+            'birthday' => '1990-05-15',
+            'version' => 1,
+            'createdAt' => now()->toISOString(),
+            'updatedAt' => now()->toISOString(),
+        ]);
+
+        // Save customer
+        Square::setMerchant($this->merchant)
+            ->setCustomer($customer)
+            ->save();
+
+        // Verify birthday is stored
+        $this->assertEquals('1990-05-15', $customer->birthday->format('Y-m-d'));
+
+        $this->assertDatabaseHas('nikolag_customers', [
+            'payment_service_id' => 'CUSTOMER_BIRTHDAY_123',
+        ]);
+    }
+
+    /**
+     * Test customer with reference_id field is properly synced.
+     */
+    public function test_create_customer_with_reference_id(): void
+    {
+        $customer = factory(Customer::class)->create([
+            'first_name' => 'Reference',
+            'last_name' => 'Test',
+            'email' => 'reference@example.com',
+            'reference_id' => 'EXTERNAL_REF_123',
+        ]);
+
+        // Mock the create customer API call with reference_id
+        $this->mockCreateCustomerSuccess([
+            'id' => 'CUSTOMER_REF_123',
+            'givenName' => 'Reference',
+            'familyName' => 'Test',
+            'emailAddress' => 'reference@example.com',
+            'referenceId' => 'EXTERNAL_REF_123',
+            'version' => 1,
+            'createdAt' => now()->toISOString(),
+            'updatedAt' => now()->toISOString(),
+        ]);
+
+        // Save customer
+        Square::setMerchant($this->merchant)
+            ->setCustomer($customer)
+            ->save();
+
+        // Verify reference_id is stored
+        $this->assertEquals('EXTERNAL_REF_123', $customer->reference_id);
+
+        $this->assertDatabaseHas('nikolag_customers', [
+            'payment_service_id' => 'CUSTOMER_REF_123',
+            'reference_id' => 'EXTERNAL_REF_123',
+        ]);
+    }
+}


### PR DESCRIPTION
This is to remain draft until https://github.com/NikolaGavric94/laravel-square/pull/117 has been merged

In order to support more complex work flows like linking a customer to a fulfillment, and then referencing the customer's address for the fulfillment (or a similar workflow with invoices), we need access to the customer's address. 

## New Fields

This PR introduces a migration that adds the following fields to the customer model:
- `birthday`: `DATE`
- `reference_id`: `STRING`
- `creation_source`: `ENUM`
- `payment_service_version`: `INT`

In addition, it introduces new JSON fields:
- `preferences`
- `group_ids`
- `segment_ids`
- `tax_ids`

## New Service Methods

To better isolate the create and update mechanisms within the `SquareService` class, there is a new `setCreateOrUpdateCustomerRequest` method that is called when the user calls `setCustomer`.  The `_saveCustomer` mechanism (triggered via the `SquareService`'s `save()` function) is also modified: it's now broken out into two distinct methods for more clarity: `_createCustomer` and `_updateCustomer`.

## Added Tests

Additional tests have been added to validate these new fields, and the new SquareService functionality.
