### PR TITLE
Adds getClient to SquareConfig

### DIFF
--- a/src/SquareConfig.php
+++ b/src/SquareConfig.php
@@ -113,6 +113,16 @@ class SquareConfig extends CoreConfig
     }
 
     /**
+     * Getter for client.
+     *
+     * @return SquareClient
+     */
+    public function getClient(): SquareClient
+    {
+        return $this->squareClient;
+    }
+
+    /**
      * Getter for config.
      *
      * @return array


### PR DESCRIPTION
When accessing the Square Config, in particular in multi-tenant scenarios where you need to access multiple connections to square across a single app - it can be helpful to extend functionality not supported by the SquareService.  

This change adds a getter to the private property `$this->squareClient` in the `SquareConfig` file to allow for more customizations across the connection.

For example, to retrieve the access token, you could now run
```
$squareService->getConfig()->getClient()->getBearerAuthCredentials()->getAccessToken();
```